### PR TITLE
Copy hiprand.dll to client build folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
 
-## (Unreleased) hipRAND-2.10.17 for ROCm 5.5.0
+## (Unreleased) hipRAND-2.10.17 for ROCm 5.6.0
 ### Fixed
 - Fixed benchmark and unit test builds on Windows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
 
+## (Unreleased) hipRAND-2.10.17 for ROCm 5.5.0
+### Fixed
+- Fixed benchmark and unit test builds on Windows.
+
 ## (Unreleased) hipRAND-2.10.16 for ROCm 5.5.0
 ### Added
 - rocRAND backend support for Sobol 64, Scrambled Sobol 32 and 64, and MT19937.
@@ -9,11 +13,11 @@ Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/e
 ### Changed
 - Python 2.7 is no longer officially supported.
 
-## (Unreleased) hipRAND for ROCm 5.2.0
+## hipRAND for ROCm 5.2.0
 ### Added
 - Backward compatibility for deprecated `#include <hiprand.h>` using wrapper header files.
 - Packages for test and benchmark executables on all supported OSes using CPack.
 
-## (Unreleased) hipRAND for ROCm 5.0.0
+## hipRAND for ROCm 5.0.0
 ### Added
 - Initial split from rocRAND

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -105,10 +105,25 @@ endif()
 
 # install library to C:\hipSDK\bin
 if (WIN32)
-  install (TARGETS hiprand DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
-  if (BUILD_TEST)
-      install (TARGETS hiprand DESTINATION "${CMAKE_BINARY_DIR}/test")
-  endif()
+    install (TARGETS hiprand DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+    if (BUILD_TEST)
+	    add_custom_command(
+		    TARGET hiprand 
+		    POST_BUILD
+		    COMMAND ${CMAKE_COMMAND} -E copy
+			    $<TARGET_FILE:hiprand>
+			    ${PROJECT_BINARY_DIR}/test/$<TARGET_FILE_NAME:hiprand>
+	    )
+    endif()
+    if (BUILD_BENCHMARK)
+	    add_custom_command(
+		    TARGET hiprand 
+		    POST_BUILD
+		    COMMAND ${CMAKE_COMMAND} -E copy
+			    $<TARGET_FILE:hiprand>
+			    ${PROJECT_BINARY_DIR}/benchmark/$<TARGET_FILE_NAME:hiprand>
+	    )
+    endif()	
 endif()
 
 # Fortran wrappers for hipRAND and rocRAND


### PR DESCRIPTION
The previous copy command was no longer copying the hipRAND DLL to test or benchmark build subfolders.