### PR TITLE
Add struct prefix

### DIFF
--- a/library/include/hiprand/hiprand_hcc.h
+++ b/library/include/hiprand/hiprand_hcc.h
@@ -23,7 +23,7 @@
 
 #include <rocrand/rocrand.h>
 
-typedef rocrand_generator_base_type hiprandGenerator_st;
+typedef struct rocrand_generator_base_type hiprandGenerator_st;
 
 typedef struct rocrand_discrete_distribution_st hiprandDiscreteDistribution_st;
 


### PR DESCRIPTION
The described issue is as follows:

The below typedef is not legal in C:

typedef rocrand_generator_base_type hiprandGenerator_st;

(Link: [hiprand/hiprand_hcc.h#L26 ](https://github.com/ROCmSoftwarePlatform/hipRAND/blob/c7b8bcfa7d3907b9e00911f17761d6f51b1636c7/library/include/hiprand/hiprand_hcc.h#L26))

where the opaque type rocrand_generator_base_type is defined as follows

typedef struct rocrand_generator_base_type * rocrand_generator;

(Link: [rocrand/rocrand.h#L42](https://github.com/ROCmSoftwarePlatform/rocRAND/blob/3dd4d3ac73ed15ba29657244f9eb70638d58b60c/library/include/rocrand/rocrand.h#LL42C64-L42C64))

In order to fix this issue a struct prefix was added in hiprand/hiprand_hcc.h as below:

typedef struct rocrand_generator_base_type hiprandGenerator_st;