### PR TITLE
366827 - Disable file reorg backward compatibility support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if (NOT HIPRAND_SUBMODULE)
   endif()
 
   # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-  option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+  option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
 
   # Print configuration summary
   include(cmake/Summary.cmake)


### PR DESCRIPTION
Change Proposed:
- File Reorg backward compatibility option set to OFF
- Backward Compatibility flag in install script set to false by default.