### PR TITLE
SWDEV-415095 - Remove invalid and hardcoded RUNPATH from hiprand library

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -62,7 +62,6 @@ set_target_properties(hiprand
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/library"
         DEBUG_POSTFIX "-d"
-        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/hiprand/lib"
 )
 
 rocm_install(


### PR DESCRIPTION
The RUNPATH of libhiprand.so was having the path /opt/rocm-ver/hiprand/lib, which is invalid with file reorg backward compatibility turned off. Removed the same