### PR TITLE
Include dependencies after finding `hip`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker searc
 # Set the default value of BUILD_SHARED_LIBS
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared")
 
-# Include cmake scripts
-include(cmake/Dependencies.cmake)
 
 # Detect compiler support for target ID
 # This section is deprecated. Please use rocm_check_target_ids for future use.
@@ -101,6 +99,9 @@ else()
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} ${ROCM_PATH}/hip ${ROCM_PATH}/llvm)
   find_package(hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH})
 endif()
+
+# Include cmake scripts
+include(cmake/Dependencies.cmake)
 
 # Build option to disable -Werror
 option(DISABLE_WERROR "Disable building with Werror" ON)


### PR DESCRIPTION
On Windows rocRAND fails to find `hip` as a dependency, as it scans in module mode rather than config mode. By finding `hip` first this issue should be resolved.