### PR TITLE
5.7.1 cherry pick - Fix C++ Style Typedef

### DIFF
--- a/library/include/hiprand/hiprand_hcc.h
+++ b/library/include/hiprand/hiprand_hcc.h
@@ -23,7 +23,7 @@
 
 #include <rocrand/rocrand.h>
 
-typedef rocrand_generator_base_type hiprandGenerator_st;
+typedef struct rocrand_generator_base_type hiprandGenerator_st;
 
 typedef struct rocrand_discrete_distribution_st hiprandDiscreteDistribution_st;
 


### PR DESCRIPTION
This 5.7.1 cherry pick fixes a C++ style typedef in C compilation path by adding a struct prefix.