### PR TITLE
Add gfx94x targets

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -76,7 +76,7 @@ if (NOT BUILD_WITH_LIB STREQUAL "CUDA")
   set( AMDGPU_TARGETS "all" CACHE STRING "Compile for which gpu architectures?")
   # Set the AMDGPU_TARGETS with backward compatiblity
   rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030;gfx1100;gfx1101;gfx1102"
+      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102"
   )
   if (AMDGPU_TARGETS)
       if( AMDGPU_TARGETS STREQUAL "all" )


### PR DESCRIPTION
@lawruble13 As a side note, maybe we should consider moving the AMDGPU_TARGETS code to the parent CMakeLists.txt somehow, to keep it consistent with all the other mathlibs, if possible? 