### PR TITLE
Hard coded path (/opt/rocm-version) references removed from cmake files

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -90,9 +90,14 @@ rocm_install(
 )
 
 set(FORTRAN_SRCS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/hiprand/src/fortran")
-configure_file(
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(CONFIG_PACKAGE_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/hiprand)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
     src/hiprand-fortran-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/hiprand-fortran-config.cmake
+    INSTALL_DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR}
 )
 
 if (BUILD_WITH_LIB STREQUAL "CUDA")

--- a/library/src/hiprand-fortran-config.cmake.in
+++ b/library/src/hiprand-fortran-config.cmake.in
@@ -85,8 +85,8 @@
 
 # Fortran wrapper
 if(@BUILD_FORTRAN_WRAPPER@)
-    set_and_check(hiprand_FORTRAN_SRC_DIR  "${PACKAGE_PREFIX_DIR}/rocrand/src/fortran")
-    set_and_check(hiprand_FORTRAN_SRC_DIRS "${PACKAGE_PREFIX_DIR}/rocrand/src/fortran")
+    set_and_check(hiprand_FORTRAN_SRC_DIR  "${PACKAGE_PREFIX_DIR}/hiprand/src/fortran")
+    set_and_check(hiprand_FORTRAN_SRC_DIRS "${PACKAGE_PREFIX_DIR}/hiprand/src/fortran")
     set(hiprand_FORTRAN_FOUND YES)
 else()
     set(hiprand_FORTRAN_FOUND NOTFOUND)

--- a/library/src/hiprand-fortran-config.cmake.in
+++ b/library/src/hiprand-fortran-config.cmake.in
@@ -81,11 +81,12 @@
 #      target_link_libraries(bar "-lcurand" hip::hiprand)
 #    endif()
 #
+@PACKAGE_INIT@
 
 # Fortran wrapper
 if(@BUILD_FORTRAN_WRAPPER@)
-    set_and_check(hiprand_FORTRAN_SRC_DIR "@FORTRAN_SRCS_INSTALL_DIR@")
-    set_and_check(hiprand_FORTRAN_SRC_DIRS "@FORTRAN_SRCS_INSTALL_DIR@")
+    set_and_check(hiprand_FORTRAN_SRC_DIR  "${PACKAGE_PREFIX_DIR}/rocrand/src/fortran")
+    set_and_check(hiprand_FORTRAN_SRC_DIRS "${PACKAGE_PREFIX_DIR}/rocrand/src/fortran")
     set(hiprand_FORTRAN_FOUND YES)
 else()
     set(hiprand_FORTRAN_FOUND NOTFOUND)


### PR DESCRIPTION
Changes Proposed

- Hard coded path reference removed from fortran config cmake files.
- resolves issue 426645