### PR TITLE
Update deprecated __HIP_PLATFORM_NVCC__ macro

### DIFF
--- a/library/include/hiprand/hiprand.h
+++ b/library/include/hiprand/hiprand.h
@@ -64,7 +64,7 @@
 
 #if defined(__HIP_PLATFORM_AMD__)
     #include "hiprand/hiprand_rocm.h"
-#elif defined(__HIP_PLATFORM_NVCC__)
+#elif defined(__HIP_PLATFORM_NVIDIA__)
     #include "hiprand/hiprand_nvcc.h"
 #endif
 

--- a/test/test_hiprand_kernel.cpp
+++ b/test/test_hiprand_kernel.cpp
@@ -344,7 +344,7 @@ TEST(hiprand_kernel_h_default, hiprand_init)
     hiprand_kernel_h_hiprand_init_test<state_type>();
 }
 
-#ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVIDIA__
 TEST(hiprand_kernel_h_philox4x32_10, hiprand_init_nvcc)
 {
     typedef hiprandStatePhilox4_32_10_t state_type;


### PR DESCRIPTION
__HIP_PLATFORM_NVCC__ has been deprecated in favour of __HIP_PLATFORM_NVIDIA__.  We're seeing build errors in hipFFT due to the usage of the old macro.