### PR TITLE
cmake: add rocrand as package dep if building static lib

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -113,6 +113,7 @@ else()
         NAME hiprand
         NAMESPACE hip::
         DEPENDS PACKAGE hip
+        STATIC_DEPENDS PACKAGE rocrand
         INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/hiprand-fortran-config.cmake"
     )
 endif()


### PR DESCRIPTION
When a static library is built, no linking is done.  (Basically static libraries are just archives of object files.)

So if `libfoo.a` depends on `libbar.a`, CMake just has to remember that when you link `libfoo.a`, it also needs to pull in `libbar.a`.  The problem is that CMake only knows about `libbar.a` if a `find_package(bar)` is done.  This PR fixes our generated `foo-config.cmake` file to find this dependency, when we're building a static library.