### PR TITLE
Remove uint type alias

### DIFF
--- a/library/include/hiprand/hiprand_kernel_nvcc.h
+++ b/library/include/hiprand/hiprand_kernel_nvcc.h
@@ -465,7 +465,7 @@ double4 hiprand_log_normal4_double(hiprandStatePhilox4_32_10_t * state,
 
 template<class StateType>
 QUALIFIERS
-uint hiprand_poisson(StateType * state, double lambda)
+unsigned int hiprand_poisson(StateType * state, double lambda)
 {
     check_state_type<StateType>();
     return curand_poisson(state, lambda);
@@ -479,7 +479,7 @@ uint4 hiprand_poisson4(hiprandStatePhilox4_32_10_t * state, double lambda)
 
 template<class StateType>
 QUALIFIERS
-uint hiprand_discrete(StateType * state, hiprandDiscreteDistribution_t discrete_distribution)
+unsigned int hiprand_discrete(StateType * state, hiprandDiscreteDistribution_t discrete_distribution)
 {
     check_state_type<StateType>();
     return curand_discrete(state, discrete_distribution);

--- a/library/include/hiprand/hiprand_kernel_rocm.h
+++ b/library/include/hiprand/hiprand_kernel_rocm.h
@@ -673,7 +673,7 @@ QUALIFIERS double4 hiprand_log_normal4_double(hiprandStatePhilox4_32_10_t* state
 /// \param lambda - Lambda (mean) parameter of Poisson distribution
 /// \return Poisson-distributed random <tt>unsigned int</tt> value
 template<class StateType>
-QUALIFIERS uint hiprand_poisson(StateType* state, double lambda)
+QUALIFIERS unsigned int hiprand_poisson(StateType* state, double lambda)
 {
     check_state_type<StateType>();
     return rocrand_poisson(state, lambda);
@@ -700,7 +700,7 @@ QUALIFIERS uint4 hiprand_poisson4(hiprandStatePhilox4_32_10_t* state, double lam
 ///
 /// See also: hiprandCreatePoissonDistribution()
 template<class StateType>
-QUALIFIERS uint hiprand_discrete(StateType*                    state,
+QUALIFIERS unsigned int hiprand_discrete(StateType*                    state,
                                  hiprandDiscreteDistribution_t discrete_distribution)
 {
     check_state_type<StateType>();


### PR DESCRIPTION
When compiling with hipcc, the "uint" type alias is defined. When compiling directly with clang, it is not.
Changing "uint" to "unsigned int" fixes this problem.