### PR TITLE
Add rocrand to hip::hiprand interface libraries

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -70,8 +70,8 @@ if (BUILD_WITH_LIB STREQUAL "CUDA")
         ${CUDA_curand_LIBRARY}
     )
 else()
-    # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
-    target_link_libraries(hiprand PRIVATE roc::rocrand hip::device)
+    target_link_libraries(hiprand PRIVATE hip::device)
+    target_link_libraries(hiprand PUBLIC roc::rocrand hip::host)
 endif()
 
 rocm_set_soversion(hiprand ${hiprand_SOVERSION})
@@ -113,6 +113,7 @@ else()
         NAME hiprand
         NAMESPACE hip::
         DEPENDS PACKAGE hip
+        DEPENDS PACKAGE rocrand
         STATIC_DEPENDS PACKAGE rocrand
         INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/hiprand-fortran-config.cmake"
     )


### PR DESCRIPTION
There are HIP and rocRAND headers included in the hiprand public headers, so they should be linked publicly. The hiprand exported CMake config needs to searching for both hip and rocrand using find_dependency to ensure the targets are available.

Fixes #113