### PR TITLE
Enable external CI trigger pipelines

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -1,0 +1,44 @@
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+  paths:
+    exclude:
+    - .githooks
+    - .github
+    - .jenkins
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - LICENSE.txt
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - develop
+  paths:
+    exclude:
+    - .githooks
+    - .github
+    - .jenkins
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - LICENSE.txt
+  drafts: false
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/hipRAND.yml@pipelines_repo


### PR DESCRIPTION
For build triggers in public-facing CI project on Azure Pipelines: https://dev.azure.com/ROCm-CI/ROCm-CI/_build