### PR TITLE
Update CUDA Toolkit version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You must have the following installed to use hipRAND:
   * AMD ROCm Software (5.0.0 or later)
   * rocRAND library
 * For NVIDIA GPUs:
-  * CUDA Toolkit
+  * CUDA Toolkit 11.5.1 or newer
   * cuRAND library
 
 ## Build and install


### PR DESCRIPTION
CURAND_ORDERING_PSEUDO_DYNAMIC was enabled in cuRAND starting in CUDA Toolkit 11.5.1.

I'd like to make the requirement explicit in our readme, as newer versions of hipRAND won't compile if the cuRAND backend is too old, and AFAIK cuRAND is only available via being bundled with the toolkit.