### PR TITLE
Update link to rocRAND data type support

### DIFF
--- a/docs/api-reference/data-type-support.rst
+++ b/docs/api-reference/data-type-support.rst
@@ -4,10 +4,10 @@
 
 .. _data-type:
 
-====================
-Data type support
-====================
+=========================
+hipRAND data type support
+=========================
 
-The data type support in hipRAND is similar to cuRAND. On AMD hardware, the backend is provided by rocRAND. To see the data type comparison between rocRAND and cuRAND, see `rocRAND's data type support <https://rocm.docs.amd.com/projects/rocRAND/en/latest/data-type-support.html>`_ page.
+The data type support in hipRAND is similar to cuRAND. On AMD hardware, the backend is provided by rocRAND. To see the data type comparison between rocRAND and cuRAND, see :doc:`rocRAND's data type support <rocrand:api-reference/data-type-support>` page.
 
 You can find the ROCm data type support summary at `Supported data types in ROCm <https://rocm.docs.amd.com/en/latest/about/compatibility/precision-support.html#data-type-support-in-rocm-libraries>`_.


### PR DESCRIPTION
The change in the link target is required due to changes in https://github.com/ROCm/rocRAND/pull/548. It now uses intersphinx instead of always pointing to latest. I also updated the topic title for clarity.