### PR TITLE
Edit changelog format as a template for future releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,30 +3,30 @@
 Documentation for hipRAND is available at
 [https://rocm.docs.amd.com/projects/hipRAND/en/latest/](https://rocm.docs.amd.com/projects/hipRAND/en/latest/).
 
-## hipRAND-2.11.0 for ROCm 6.2.0
+## hipRAND 2.11.0 for ROCm 6.2.0
 
-### Additions
+### Added
 
 * Added support for setting generator output ordering in C and C++ API
 * `hiprandCreateGeneratorHost` dispatches to the host generator in the rocRAND backend instead of returning with `HIPRAND_STATUS_NOT_IMPLEMENTED`
 * Added the option to create a host generator to the Fortran wrapper
 * Added the option to create a host generator to the Python wrapper
 
-### Changes
+### Changed
 
 * For internal testing with HMM the environment variable `ROCRAND_USE_HMM` was used in previous
   versions, it is now changed to `HIPRAND_USE_HMM`.
 * The device API documentation is improved in this version.
 * Static library: moved all internal symbols to namespaces to avoid potential symbol name collisions when linking.
 
-### Removals
+### Removed
 
 * Removed the option to build hipRAND as a submodule to rocRAND
 * Removed references to, and workarounds for, the deprecated `hcc`
 * Support for finding rocRAND based on the environment variable `ROCRAND_DIR` has been removed
   `ROCRAND_PATH` can be used instead.
 
-### Fixes
+### Resolved issues
 
 * Build error when using Clang++ directly due to unsupported references to `amdgpu-target`
 


### PR DESCRIPTION
This converts the 6.2.0 changelog to the correct format so it can serve as a template for future releases.