### PR TITLE
Include 6.2.4 version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Documentation for hipRAND is available at
 
 ### Added
 
-* GFX1151 Suport
+* GFX1151 Support
 
 ## hipRAND 2.11.0 for ROCm 6.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for hipRAND is available at
 [https://rocm.docs.amd.com/projects/hipRAND/en/latest/](https://rocm.docs.amd.com/projects/hipRAND/en/latest/).
 
+## hipRAND-2.11.1 for ROCm 6.2.4
+
+### Added
+
+* GFX1151 Suport
+
 ## hipRAND 2.11.0 for ROCm 6.2.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # hipRAND project
 #
 project(hipRAND CXX)
-set(hipRAND_VERSION "2.11.0")
+set(hipRAND_VERSION "2.11.1")
 
 # Build options
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)


### PR DESCRIPTION
We need to keep packaging versions up to date (ie. no regressions) otherwise Upgrade Installation methods don't work.