### PR TITLE
Guard against spaces in HIP_PATH on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Documentation for hipRAND is available at
   
 ### Resolved issues
 
-* Fixed an issue that was causing hipRAND build failures on Windows when the HIP SDK was installed to a location whose path contained spaces.
+* Fixed an issue that was causing hipRAND build failures on Windows when the HIP SDK was installed to a location with a path that contains spaces.
 
 ## hipRAND-2.11.1 for ROCm 6.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Documentation for hipRAND is available at
 
 ### Changed
 
-* When building hipRAND on Windows, please use `HIP_PATH` (instead of the former `HIP_DIR`) to specify the path to your HIP SDK installation.
+* When building hipRAND on Windows, use `HIP_PATH` (instead of the former `HIP_DIR`) to specify the path to the HIP SDK installation.
   * When building with the `rmake.py` script, if `HIP_PATH` is not set, it will default to `C:\hip`.
   
 ### Resolved issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Documentation for hipRAND is available at
 [https://rocm.docs.amd.com/projects/hipRAND/en/latest/](https://rocm.docs.amd.com/projects/hipRAND/en/latest/).
 
+## hipRAND-2.12.0 for ROCm 6.5.0
+
+### Changed
+
+* When building hipRAND on Windows, please use `HIP_PATH` (instead of the former `HIP_DIR`) to specify the path to your HIP SDK installation.
+  * When building with the `rmake.py` script, if `HIP_PATH` is not set, it will default to `C:\hip`.
+  
+### Resolved issues
+
+* Fixed an issue that was causing hipRAND build failures on Windows when the HIP SDK was installed to a location whose path contained spaces.
+
 ## hipRAND-2.11.1 for ROCm 6.2.4
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # hipRAND project
 #
 project(hipRAND CXX)
-set(hipRAND_VERSION "2.11.1")
+set(hipRAND_VERSION "2.12.0")
 
 # Build options
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)

--- a/rmake.py
+++ b/rmake.py
@@ -87,10 +87,11 @@ def config_cmd():
     cmake_executable = ""
     cmake_options = []
     cmake_platform_opts = []
-    
+
     if (OS_info["ID"] == 'windows'):
         # we don't have ROCM on windows but have hip, ROCM can be downloaded if required
-        rocm_path = os.getenv( 'ROCM_PATH', "C:/hipsdk/rocm-cmake-master") #C:/hip") # rocm/Utils/cmake-rocm4.2.0"
+        raw_rocm_path = cmake_path(os.getenv('HIP_PATH', "C:/hip"))
+        rocm_path = f'"{raw_rocm_path}"' # guard against spaces in path
         cmake_executable = "cmake.exe"
         toolchain = os.path.join( src_path, "toolchain-windows.cmake" )
         #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation
@@ -174,6 +175,11 @@ def config_cmd():
 
     return cmake_executable, cmd_opts
 
+def cmake_path(os_path):
+    if OS_info["ID"] == "windows":
+        return os_path.replace("\\", "/")
+    else:
+        return os.path.realpath(os_path)
 
 def make_cmd():
     global args

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -3,7 +3,10 @@
 # Ninja doesn't support platform
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
-if (DEFINED ENV{HIP_DIR})
+if (DEFINED ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+elseif (DEFINED ENV{HIP_DIR})
   file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
   set(rocm_bin "${HIP_DIR}/bin")
 else()
@@ -11,30 +14,23 @@ else()
   set(rocm_bin "C:/hip/bin")
 endif()
 
-#set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc.bat")
-#set(CMAKE_C_COMPILER "${rocm_bin}/hipcc.bat")
 set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
-
-#set(CMAKE_CXX_LINKER "${rocm_bin}/hipcc.bat" )
 
 # TODO remove, just to speed up slow cmake
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
-#
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -D_CRT_SECURE_NO_WARNINGS")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include -D_CRT_SECURE_NO_WARNINGS")
+# our usage flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
 
 # flags for clang direct use with hip
 # -x hip causes linker error
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)
@@ -42,8 +38,3 @@ else()
   set(VCPKG_PATH "C:/github/vcpkg")
 endif()
 include("${VCPKG_PATH}/scripts/buildsystems/vcpkg.cmake")
-# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
-# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
-# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
-# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
-# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")


### PR DESCRIPTION
If you install the hipSDK on Windows using the installer executable, the default install location is in "C:\Program Files\...". The installer also sets the HIP_PATH environment variable to that location.

This can cause problems in CMake, since the space character in the path causes the path to be interpreted as a list with two items.

This change does the following to fix this problem:

- allow the HIP installation path to be specified using the HIP_PATH environment variable instead of HIP_DIR (this was changed in rocRAND a while back, but never made it into hipRAND).

- remove "-I${HIP_DIR}/include" from CMAKE_CXX_FLAGS, since HIP_DIR can include spaces, which causes the path to be interpreted as two separate arguments. This include flag is no longer necessary, and was removed in rocRAND a while back.

- modify rmake.py to bring in updated changes from rocRAND's version of the script. These changes ensure that the string in the rocm_path variable is quoted (so spaces won't be an issue). This then causes CMAKE_PREFIX_PATH to be set with the quoted string and passed into cmake via the shell call. Passing in the quoted string using the shell call eliminates the need to quote HIP_PATH / HIP_DIR / CMAKE_PREFIX_PATH within the hipRAND cmake source files, which I was unable to find a reliable way to do.

This change also removes some dead commented code in toolchain-windows.cmake.