### PR TITLE
Refresh hipRAND documentation

### DIFF
--- a/docs/api-reference/cpp-api.rst
+++ b/docs/api-reference/cpp-api.rst
@@ -1,5 +1,5 @@
 .. meta::
-   :description: A wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer
+   :description: hipRAND C/C++ API reference
    :keywords: hipRAND, ROCm, library, API, tool
 
 .. _cpp-api:
@@ -10,14 +10,14 @@ C/C++ API reference
 
 This document describes the hipRAND APIs available in C and C++.
 
-Device Functions
+Device functions
 ================
 .. doxygengroup:: hipranddevice
 
-C Host API
+C host API
 ==========
 .. doxygengroup:: hiprandhost
 
-C++ Host API Wrapper
+C++ host API wrapper
 ====================
 .. doxygengroup:: hiprandhostcpp

--- a/docs/api-reference/data-type-support.rst
+++ b/docs/api-reference/data-type-support.rst
@@ -1,6 +1,6 @@
 .. meta::
-   :description: A wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer
-   :keywords: hipRAND, ROCm, library, API, tool
+   :description: hipRAND data type support
+   :keywords: hipRAND, ROCm, library, API, tool, data types
 
 .. _data-type:
 
@@ -8,6 +8,7 @@
 hipRAND data type support
 =========================
 
-The data type support in hipRAND is similar to cuRAND. On AMD hardware, the backend is provided by rocRAND. To see the data type comparison between rocRAND and cuRAND, see :doc:`rocRAND's data type support <rocrand:api-reference/data-type-support>` page.
+The data type support in hipRAND is similar to NVIDIA CUDA cuRAND. On AMD hardware, the backend is provided by rocRAND. To see the data type comparison between
+rocRAND and cuRAND, see :doc:`rocRAND data type support <rocrand:api-reference/data-type-support>`.
 
-You can find the ROCm data type support summary at `Supported data types in ROCm <https://rocm.docs.amd.com/en/latest/about/compatibility/precision-support.html#data-type-support-in-rocm-libraries>`_.
+You can find a summary of the ROCm data type support at `Supported data types in ROCm <https://rocm.docs.amd.com/en/latest/about/compatibility/precision-support.html#data-type-support-in-rocm-libraries>`_.

--- a/docs/api-reference/python-api.rst
+++ b/docs/api-reference/python-api.rst
@@ -1,6 +1,6 @@
 .. meta::
-   :description: A wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer
-   :keywords: hipRAND, ROCm, library, API, tool
+   :description: hipRAND Python API reference
+   :keywords: hipRAND, ROCm, library, API, tool, Python
 
 .. _python-api:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ left_nav_title = f"hipRAND {version_number} Documentation"
 # for PDF output on Read the Docs
 project = "hipRAND Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 

--- a/docs/how-to/use-hiprand-interfaces.rst
+++ b/docs/how-to/use-hiprand-interfaces.rst
@@ -1,0 +1,39 @@
+.. meta::
+   :description: hipRAND interface usage notes
+   :keywords: hipRAND, ROCm, library, API, tool, interface, usage
+
+
+*******************************************************************
+Using hipRAND interfaces
+*******************************************************************
+
+The hipRAND interface is compatible with the rocRAND and the NVIDIA CUDA cuRAND-v2 APIs.
+Porting a CUDA application that calls the cuRAND API to an application that calls the hipRAND API is relatively straightforward.
+
+Host API
+===============================
+
+For example, to create a generator, follow this example:
+
+.. code-block:: cpp
+
+   hiprandStatus_t
+   hiprandCreateGenerator(
+      hiprandGenerator_t* generator,
+      hiprandRngType_t rng_type
+   )
+
+Device API
+===============================
+
+Here is an example that generates a log-normally distributed float from a generator.
+These functions are templated for all generators.
+
+.. code-block:: cpp
+
+   __device__ double
+   hiprand_log_normal_double(
+      hiprandStateSobol64_t* state,
+      double mean,
+      double stddev
+   )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. meta::
-   :description: A wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer
+   :description: Introduction to the hipRAND wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer
    :keywords: hipRAND, ROCm, library, API, tool
 
 .. _index:
@@ -8,28 +8,36 @@
 hipRAND documentation
 ===========================
 
-The hipRAND library is a wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer. hipRAND uses rocRAND in a ROCm environment and cuRAND in a CUDA environment.
+The hipRAND library is a wrapper library that lets you easily port NVIDIA CUDA applications that use the CUDA cuRAND library
+to the HIP layer. It sits between your application and the backend RAND library,
+where it marshals inputs to the backend and results to the application. hipRAND exports an interface that doesn't
+require the client to change, regardless of the chosen backend.
+It uses rocRAND in a ROCm environment and cuRAND in a CUDA environment and provides C, C++, and Python API wrappers.
 
-hipRAND provides C, C++, and Python API wrappers.
+The hipRAND public repository is located at `<https://github.com/ROCm/hipRAND>`_.
 
-You can access hipRAND code on our `GitHub repository <https://github.com/ROCm/hipRAND>`_.
-
-The documentation is structured as follows:
 
 .. grid:: 2
   :gutter: 3
 
   .. grid-item-card:: Install
 
-    * :ref:`installation`
-    
+    * :doc:`Installation guide <./install/installation>`    
+
+  .. grid-item-card:: How to
+
+    * :doc:`Use hipRAND interfaces <./how-to/use-hiprand-interfaces>`    
+
+  .. grid-item-card:: Examples
+
+    * `Examples <https://github.com/ROCm/hipRAND/tree/develop/python/hiprand/examples>`_
+
   .. grid-item-card:: API reference
 
     * :ref:`data-type`
     * :ref:`cpp-api`
     * :ref:`python-api`
      
-To contribute to the documentation, refer to
-`Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
+To contribute to the documentation, see `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.

--- a/docs/install/installation.rst
+++ b/docs/install/installation.rst
@@ -172,7 +172,7 @@ The hipRAND Python API Wrapper requires the following dependencies:
 
 .. note::
     
-   If hipRAND is built from source but is either not installed or iinstalled in a
+   If hipRAND is built from source but is either not installed or installed in a
    non-standard directory, then set the ``ROCRAND_PATH`` or ``HIPRAND_PATH`` environment variable to the
    path containing ``libhiprand.so`` as shown below:
 

--- a/docs/install/installation.rst
+++ b/docs/install/installation.rst
@@ -1,80 +1,82 @@
 .. meta::
-   :description: A wrapper library that allows you to easily port CUDA applications that use the cuRAND library to the HIP layer
-   :keywords: hipRAND, ROCm, library, API, tool
+   :description: hipRAND installation guide
+   :keywords: hipRAND, ROCm, library, API, tool, installation, build, Python wrapper
 
 .. _installation:
 
-============
-Installation
-============
+*******************************************************************
+Installing and building hipRAND
+*******************************************************************
 
-To install hipRAND, you can choose between the following two methods:
+To install hipRAND, choose between the following two methods:
 
 -   :ref:`Using prebuilt packages from the ROCm repositories <prebuilt-packages>`
 -   :ref:`Building from source <build-from-source>`   
 
-Both the methods are described below.
-
 .. _prebuilt-packages:
 
 Install using prebuilt packages
---------------------------------
+===============================
 
-To install the prebuilt hipRAND packages, you require a ROCm-enabled platform. For information on ROCm installation, see the `ROCm installation for Linux <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ page. After installing ROCm or enabling the ROCm repositories, you can install hipRAND using the system package manager.
+The prebuilt hipRAND packages require a ROCm-enabled platform.
+For information on installing ROCm, see the `ROCm installation guide <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_.
+After installing ROCm or enabling the ROCm repositories, use the system package manager to install hipRAND.
 
 For Ubuntu and Debian:
 
 .. code-block:: shell
 
-    sudo apt-get install hiprand
+   sudo apt-get install hiprand
 
-For CentOS:
+For CentOS-based systems:
 
 .. code-block:: shell
 
-    sudo yum install hiprand
+   sudo yum install hiprand
 
 For SLES:
 
 .. code-block:: shell
 
-    sudo dnf install hiprand
+   sudo dnf install hiprand
 
-This installs hipRAND in the ``/opt/rocm`` directory.
+These commands install hipRAND in the ``/opt/rocm`` directory.
 
 .. _build-from-source:
 
 Build hipRAND from source
-----------------------------
+===============================
 
 This section provides the information required to build hipRAND from source.
 
 Requirements
-^^^^^^^^^^^^
+----------------------------
 
-To build hipRAND, CMake version 3.10 or later is required.
+To build hipRAND, CMake version 3.16 or later is required.
 
-Additionally, to build hipRAND for ROCm software, the following softwares are required:
+Additionally, to build hipRAND for the ROCm platform, the following components are required:
 
-* `AMD ROCm Software <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ (version 5.0.0 or later).
+* `ROCm Software <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ (version 5.0.0 or later)
 * `rocRAND <https://github.com/ROCm/rocRAND.git>`_
 
-To build hipRAND for the CUDA platform instead, the following softwares are required:
+To build hipRAND for the CUDA platform, the following applications are required:
 
-* The CUDA toolkit
+* The CUDA toolkit (version 11.5.1 or newer)
 * cuRAND (included in the CUDA Toolkit)
 
-Obtaining sources
-^^^^^^^^^^^^^^^^^
+Downloading the source code
+----------------------------
 
-You can find the hipRAND sources in the `hipRAND GitHub Repository <https://github.com/ROCm/hipRAND>`_. Use the branch that matches the system-installed version of ROCm. For example, on a system with ROCm 5.4 installed, use the following command to obtain hipRAND sources:
+You can find the hipRAND source code in the `hipRAND GitHub Repository <https://github.com/ROCm/hipRAND>`_.
+Use the branch that matches the ROCm version installed on the system.
+For example, on a system with ROCm 6.3 installed, use the following command to obtain the hipRAND version 6.3 source code:
 
 .. code-block:: shell
 
-    git checkout -b release/rocm-rel-5.4 https://github.com/ROCm/hipRAND.git
+    git checkout -b release/rocm-rel-6.3 https://github.com/ROCm/hipRAND.git
 
-Building library
-^^^^^^^^^^^^^^^^^^^^
+Building the library
+----------------------------
 
 After obtaining the sources and dependencies, build hipRAND for ROCm software using the installation script:
 
@@ -83,12 +85,18 @@ After obtaining the sources and dependencies, build hipRAND for ROCm software us
     cd hipRAND
     ./install --install
 
-This automatically builds all required dependencies, excluding Git and the requirements listed above, and installs the project to ``/opt/rocm`` if everything went well. See ``./install --help`` for further information. The clients, enabled by option ``--clients``, consist of the hipRAND tests and add the additional dependency of `googletest <https://github.com/google/googletest>`_.
+This automatically builds all required dependencies, excluding Git and the requirements listed above,
+and installs the project to ``/opt/rocm``. For further information, run the ``./install --help`` command.
+
+The clients, which are enabled using the ``--clients`` option, consist of the hipRAND tests and add the additional dependency
+of `GoogleTest <https://github.com/google/googletest>`_.
 
 Building with CMake
-^^^^^^^^^^^^^^^^^^^
+----------------------------
 
-For a more elaborate installation process, build hipRAND manually using CMake. This enables certain configuration options that are not exposed to the ``./install`` script. In general, you can build hipRAND using CMake with the following configuration:
+For a more detailed installation process, build hipRAND manually using CMake.
+This enables certain configuration options that are not available through the ``./install`` script.
+To build hipRAND, use CMake with the following configuration:
 
 .. code-block:: shell
 
@@ -102,80 +110,89 @@ For a more elaborate installation process, build hipRAND manually using CMake. T
     # Install
     [sudo] make install
 
-Where ``<compiler>`` should be set to ``hipcc`` or ``amdclang`` on ROCm software or to a regular C++ compiler such as ``g++`` on a CUDA platform. The default build configuration is ``Release``.
+Where ``<compiler>`` should be set to ``hipcc`` or ``amdclang`` for ROCm or to a regular C++ compiler such as ``g++`` on a CUDA platform.
+The default build configuration is ``Release``.
 
 Here are the CMake options:
 
-* ``BUILD_WITH_LIB`` decides whether to build hipRAND with the rocRAND or cuRAND backend. If set to ``CUDA``, hipRAND is built using the cuRAND backend. Otherwise, the rocRAND backend is used.
-* ``BUILD_FORTRAN_WRAPPER`` builds the Fortran wrapper when set to ``ON``. Defaults to ``OFF``.
-* ``BUILD_TEST`` builds the hipRAND tests when set to ``ON``. Defaults to ``OFF``.
-* ``BUILD_BENCHMARK`` builds the hipRAND benchmarks when set to ``ON``. Defaults to ``OFF``.
-* ``BUILD_ADDRESS_SANITIZER`` builds with address sanitization enabled when set to ``ON``. Defaults to ``OFF``.
-* ``ROCRAND_PATH`` specifies a rocRAND install other than the default system installed one.
-* ``DOWNLOAD_ROCRAND`` downloads and installs rocRAND in the build directory when set to ``ON``. Defaults to ``OFF``.
-* ``DEPENDENCIES_FORCE_DOWNLOAD`` downloads and builds the dependencies instead of using system-installed dependencies when set to ``ON``. Defaults to ``OFF``.
+* ``BUILD_WITH_LIB``: Determines whether to build hipRAND with the rocRAND or cuRAND backend. If it's set to ``CUDA``, hipRAND is built using the cuRAND backend. Otherwise, the rocRAND backend is used.
+* ``BUILD_FORTRAN_WRAPPER``: Builds the Fortran wrapper when set to ``ON``. Defaults to ``OFF``.
+* ``BUILD_TEST``: Builds the hipRAND tests when set to ``ON``. Defaults to ``OFF``.
+* ``BUILD_BENCHMARK``: Builds the hipRAND benchmarks when set to ``ON``. Defaults to ``OFF``.
+* ``BUILD_ADDRESS_SANITIZER``: Builds with address sanitization enabled when set to ``ON``. Defaults to ``OFF``.
+* ``ROCRAND_PATH``: Specifies a rocRAND install other than the default system installed version.
+* ``DOWNLOAD_ROCRAND``: Downloads and installs rocRAND in the build directory when set to ``ON``. Defaults to ``OFF``.
+* ``DEPENDENCIES_FORCE_DOWNLOAD``: Downloads and builds the dependencies instead of using the system-installed dependencies when set to ``ON``. Defaults to ``OFF``.
 
-If using ``ROCRAND_PATH`` or ``DOWNLOAD_ROCRAND`` when rocRAND is already installed in the default location in the system then, use ``CMAKE_NO_SYSTEM_FROM_IMPORTED=ON`` while configuring the project.
-Failing to do so might resolve the rocRAND headers to the system-installed version instead of the specified version, leading to errors or missing functionalities.
+If you are using ``ROCRAND_PATH`` or ``DOWNLOAD_ROCRAND`` when rocRAND is already installed in the default location,
+you must use the ``CMAKE_NO_SYSTEM_FROM_IMPORTED=ON`` option to configure the project.
+Failing to do so might process the rocRAND headers from the system-installed version instead of the specified version,
+leading to errors or missing functionality.
 
 Common build errors
-"""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^
 
-*   
-  .. code-block:: shell
+Use the following tips to troubleshoot build problems.
+
+*  ``rocrand`` package configuration file not found:
+
+   .. code-block:: shell
 
       Could not find a package configuration file provided by "rocrand" with any of the following names:
 
       rocrandConfig.cmake
       rocrand-config.cmake
 
-  Solution: install `rocRAND <https://github.com/ROCm/rocRAND.git>`_.
-* 
-  .. code-block:: shell
+   **Solution**: Install `rocRAND <https://github.com/ROCm/rocRAND.git>`_.
+
+*  ``ROCM`` package configuration file not found:
+
+   .. code-block:: shell
 
       Could not find a package configuration file provided by "ROCM" with any of the following names:
 
       ROCMConfig.cmake
       rocm-config.cmake
 
-  Solution: install `ROCm CMake modules <https://github.com/RadeonOpenCompute/rocm-cmake>`_.
+   **Solution**: Install the `ROCm CMake modules <https://github.com/ROCm/rocm-cmake>`_.
 
-Building Python API wrapper
--------------------------------
+Building the Python API wrapper
+===============================
 
-This section provides information required to build the hipRAND Python API wrapper.
+This section provides the information required to build the hipRAND Python API wrapper.
 
 Requirements
-^^^^^^^^^^^^
+----------------------------
 
 The hipRAND Python API Wrapper requires the following dependencies:
 
 * hipRAND
 * Python 3.5
-* NumPy (will be installed automatically as a dependency if necessary)
+* NumPy (This is installed automatically as a dependency, if necessary.)
 
 .. note::
     
-    If hipRAND is built from sources but not installed or rather installed in a
-    non-standard directory, then set the ``ROCRAND_PATH`` or ``HIPRAND_PATH`` environment variable to the path containing ``libhiprand.so`` as shown below:
+   If hipRAND is built from source but is either not installed or iinstalled in a
+   non-standard directory, then set the ``ROCRAND_PATH`` or ``HIPRAND_PATH`` environment variable to the
+   path containing ``libhiprand.so`` as shown below:
 
-    .. code-block:: shell
+   .. code-block:: shell
 
-        export HIPRAND_PATH=~/hipRAND/build/library/
+      export HIPRAND_PATH=~/hipRAND/build/library/
 
 Installation
-^^^^^^^^^^^^^
+----------------------------
 
-To install Python hipRAND module using ``pip``:
-
-.. code-block:: shell
-
-    cd hipRAND/python/hiprand
-    pip install .
-
-To execute the tests:
+To install the Python hipRAND module using ``pip``, run these commands:
 
 .. code-block:: shell
 
-    cd hipRAND/python/hiprand
-    python tests/hiprand_test.py
+   cd hipRAND/python/hiprand
+   pip install .
+
+Use these commands to run the tests:
+
+.. code-block:: shell
+
+   cd hipRAND/python/hiprand
+   python tests/hiprand_test.py

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -5,9 +5,22 @@ subtrees:
 - caption: Install
   entries:
   - file: install/installation
+    title: Installation guide
+
+- caption: How to
+  entries:
+  - file: how-to/use-hiprand-interfaces
+    title: Use hipRAND interfaces
+
+- caption: Examples
+  entries:
+  - url: https://github.com/ROCm/hipRAND/tree/develop/python/hiprand/examples
+    title: Examples
+
 - caption: API reference
   entries:
   - file: api-reference/data-type-support
+    title: Data type support
   - file: api-reference/cpp-api
   - file: api-reference/python-api
 - caption: About


### PR DESCRIPTION
This PR provides copy edits and formatting fixes for the hipRAND ROCm documentation. It organizes the index page, adds a link to the examples, and add some information from the read me to the install guide and a new usage guide (which describes the interface use).