### PR TITLE
Mergeback 6.4 changes (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for hipRAND is available at
 [https://rocm.docs.amd.com/projects/hipRAND/en/latest/](https://rocm.docs.amd.com/projects/hipRAND/en/latest/).
 
-## hipRAND 2.12.0 for ROCm 6.5
+## hipRAND 2.13.0 for ROCm 6.5.0
 
 ### Added 
 
@@ -17,11 +17,7 @@ Documentation for hipRAND is available at
 
 * C++14 will be deprecated in the next major release.
 
-## hipRAND-2.11.1 for ROCm 6.2.4
-
-### Added
-
-* GFX1151 Support
+## hipRAND 2.12.0 for ROCm 6.4.0
 
 ### Changed
 
@@ -31,6 +27,12 @@ Documentation for hipRAND is available at
 ### Resolved issues
 
 * Fixed an issue that was causing hipRAND build failures on Windows when the HIP SDK was installed to a location with a path that contains spaces.
+
+## hipRAND-2.11.1 for ROCm 6.2.4
+
+### Added
+
+* GFX1151 Support
 
 ## hipRAND 2.11.0 for ROCm 6.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Documentation for hipRAND is available at
 
 * C++14 will be deprecated in the next major release.
 
+## hipRAND-2.11.1 for ROCm 6.2.4
+
+### Added
+
+* GFX1151 Support
+
+### Changed
+
+* When building hipRAND on Windows, use `HIP_PATH` (instead of the former `HIP_DIR`) to specify the path to the HIP SDK installation.
+  * When building with the `rmake.py` script, if `HIP_PATH` is not set, it will default to `C:\hip`.
+  
+### Resolved issues
+
+* Fixed an issue that was causing hipRAND build failures on Windows when the HIP SDK was installed to a location with a path that contains spaces.
+
 ## hipRAND 2.11.0 for ROCm 6.2.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # hipRAND project
 #
 project(hipRAND CXX)
-set(hipRAND_VERSION "2.12.0")
+set(hipRAND_VERSION "2.13.0")
 
 # Build options
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)

--- a/rmake.py
+++ b/rmake.py
@@ -87,10 +87,11 @@ def config_cmd():
     cmake_executable = ""
     cmake_options = []
     cmake_platform_opts = []
-    
+
     if (OS_info["ID"] == 'windows'):
         # we don't have ROCM on windows but have hip, ROCM can be downloaded if required
-        rocm_path = os.getenv( 'ROCM_PATH', "C:/hipsdk/rocm-cmake-master") #C:/hip") # rocm/Utils/cmake-rocm4.2.0"
+        raw_rocm_path = cmake_path(os.getenv('HIP_PATH', "C:/hip"))
+        rocm_path = f'"{raw_rocm_path}"' # guard against spaces in path
         cmake_executable = "cmake.exe"
         toolchain = os.path.join( src_path, "toolchain-windows.cmake" )
         #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation
@@ -174,6 +175,11 @@ def config_cmd():
 
     return cmake_executable, cmd_opts
 
+def cmake_path(os_path):
+    if OS_info["ID"] == "windows":
+        return os_path.replace("\\", "/")
+    else:
+        return os.path.realpath(os_path)
 
 def make_cmd():
     global args

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -3,7 +3,10 @@
 # Ninja doesn't support platform
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
-if (DEFINED ENV{HIP_DIR})
+if (DEFINED ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+elseif (DEFINED ENV{HIP_DIR})
   file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
   set(rocm_bin "${HIP_DIR}/bin")
 else()
@@ -11,30 +14,23 @@ else()
   set(rocm_bin "C:/hip/bin")
 endif()
 
-#set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc.bat")
-#set(CMAKE_C_COMPILER "${rocm_bin}/hipcc.bat")
 set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
-
-#set(CMAKE_CXX_LINKER "${rocm_bin}/hipcc.bat" )
 
 # TODO remove, just to speed up slow cmake
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
-#
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -D_CRT_SECURE_NO_WARNINGS")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include -D_CRT_SECURE_NO_WARNINGS")
+# our usage flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
 
 # flags for clang direct use with hip
 # -x hip causes linker error
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)
@@ -42,8 +38,3 @@ else()
   set(VCPKG_PATH "C:/github/vcpkg")
 endif()
 include("${VCPKG_PATH}/scripts/buildsystems/vcpkg.cmake")
-# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
-# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
-# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
-# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
-# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")


### PR DESCRIPTION
Merge back changes from the release-staging/rocm-rel-6.5 branch.

* Include 6.2.4 version update (#202)

* Cherry-pick to release-staging/rocm-rel-6.4: Update license file for 2025  (#210)

* Update license file for 2025 (#207)

* Update license file to include start and end years (#208)

* Guard against spaces in HIP_PATH on Windows