### PR TITLE
Develop stream 2025-05-07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,23 +3,19 @@
 Documentation for hipRAND is available at
 [https://rocm.docs.amd.com/projects/hipRAND/en/latest/](https://rocm.docs.amd.com/projects/hipRAND/en/latest/).
 
-## (unreleased) hipRAND x.y.z for ROCm 7.0
+## hipRAND 2.13.0 for ROCm 7.0
 
-* Deprecated hipRAND's Fortran API in favor of hipfort.
-
-## hipRAND 2.13.0 for ROCm 6.5.0
-
-### Added 
+### Added
 
 * gfx950 support
 
 ### Changed
 
-* Changed the C++ version from 14 to 17.
+* Deprecated hipRAND's Fortran API in favor of hipfort.
 
-### Upcoming changes
+### Removed
 
-* C++14 will be deprecated in the next major release.
+* Removed C++14 support, only C++17 is supported.
 
 ## hipRAND 2.12.0 for ROCm 6.4.0
 
@@ -27,7 +23,7 @@ Documentation for hipRAND is available at
 
 * When building hipRAND on Windows, use `HIP_PATH` (instead of the former `HIP_DIR`) to specify the path to the HIP SDK installation.
   * When building with the `rmake.py` script, if `HIP_PATH` is not set, it will default to `C:\hip`.
-  
+
 ### Resolved issues
 
 * Fixed an issue that was causing hipRAND build failures on Windows when the HIP SDK was installed to a location with a path that contains spaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,10 @@ Documentation for hipRAND is available at
 
 * gfx950 support
 
-### Changed
-
-* Changed the C++ version from 14 to 17. 
-
 ### Upcoming changes
 
-* C++14 will be deprecated in the next major release.
+* Changed the C++ version from 14 to 17. C++14 will be deprecated in the next major release.
+* Deprecated hipRAND's Fortran API in favor of hipfort.
 
 ## hipRAND 2.12.0 for ROCm 6.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,23 @@
 Documentation for hipRAND is available at
 [https://rocm.docs.amd.com/projects/hipRAND/en/latest/](https://rocm.docs.amd.com/projects/hipRAND/en/latest/).
 
+## (unreleased) hipRAND x.y.z for ROCm 7.0
+
+* Deprecated hipRAND's Fortran API in favor of hipfort.
+
 ## hipRAND 2.13.0 for ROCm 6.5.0
 
 ### Added 
 
 * gfx950 support
 
+### Changed
+
+* Changed the C++ version from 14 to 17.
+
 ### Upcoming changes
 
-* Changed the C++ version from 14 to 17. C++14 will be deprecated in the next major release.
-* Deprecated hipRAND's Fortran API in favor of hipfort.
+* C++14 will be deprecated in the next major release.
 
 ## hipRAND 2.12.0 for ROCm 6.4.0
 

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,44 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-function (print_configuration_summary)
+function(print_configuration_summary)
+    find_package(Git)
+    if(GIT_FOUND)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} show --format=%H --no-patch
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} show --format=%s --no-patch
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE COMMIT_SUBJECT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
+
+    execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} --version
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE CMAKE_CXX_COMPILER_VERBOSE_DETAILS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    find_program(UNAME_EXECUTABLE uname)
+    if(UNAME_EXECUTABLE)
+        execute_process(
+            COMMAND ${UNAME_EXECUTABLE} -a
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE LINUX_KERNEL_DETAILS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()  
+
+    string(REPLACE "\n" ";" CMAKE_CXX_COMPILER_VERBOSE_DETAILS "${CMAKE_CXX_COMPILER_VERBOSE_DETAILS}")
+    list(TRANSFORM CMAKE_CXX_COMPILER_VERBOSE_DETAILS PREPEND "--     ")
+    string(REPLACE ";" "\n" CMAKE_CXX_COMPILER_VERBOSE_DETAILS "${CMAKE_CXX_COMPILER_VERBOSE_DETAILS}")
+
     message(STATUS "")
     message(STATUS "******** Summary ********")
     message(STATUS "General:")
@@ -54,4 +91,15 @@ endif()
     message(STATUS "  BUILD_ADDRESS_SANITIZER    : ${BUILD_ADDRESS_SANITIZER}")
     message(STATUS "  DOWNLOAD_ROCRAND           : ${DOWNLOAD_ROCRAND}")
     message(STATUS "  DEPENDENCIES_FORCE_DOWNLOAD: ${DEPENDENCIES_FORCE_DOWNLOAD}")
+    message(STATUS "")
+    message(STATUS "Detailed:")
+    message(STATUS "  C++ compiler details       : \n${CMAKE_CXX_COMPILER_VERBOSE_DETAILS}")
+if(GIT_FOUND)
+    message(STATUS "  Commit                     : ${COMMIT_HASH}")
+    message(STATUS "                               ${COMMIT_SUBJECT}")
+endif()
+if(UNAME_EXECUTABLE)
+    message(STATUS "  Unix name                  : ${LINUX_KERNEL_DETAILS}")
+endif()
+  
 endfunction()

--- a/library/include/hiprand/hiprand_kernel_nvcc.h
+++ b/library/include/hiprand/hiprand_kernel_nvcc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -218,7 +218,11 @@ QUALIFIERS void hiprand_init(hiprandDirectionVectors64_t     direction_vectors,
 
 template<class StateType>
 QUALIFIERS
-void skipahead(unsigned long long n, StateType * state)
+    typename std::enable_if<!std::is_same<StateType, curandStateSobol32>::value
+                            && !std::is_same<StateType, curandStateScrambledSobol32>::value
+                            && !std::is_same<StateType, curandStateSobol64>::value
+                            && !std::is_same<StateType, curandStateScrambledSobol64>::value>::type
+    skipahead(unsigned long long n, StateType* state)
 {
     check_state_type<StateType>();
     static_assert(

--- a/library/include/hiprand/hiprand_mtgp32_host.h
+++ b/library/include/hiprand/hiprand_mtgp32_host.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -74,11 +74,11 @@ inline hiprandStatus_t hiprandMakeMTGP32Constants(const mtgp32_params_fast_t par
  * - HIPRAND_STATUS_ALLOCATION_FAILED if states could not be initialized
  * - HIPRAND_STATUS_SUCCESS if states are initialized
  */
-inline hiprandStatus_t hiprandMakeMTGP32KernelState(hiprandStateMtgp32_t*   s,
-                                                    mtgp32_params_fast_t    params[],
-                                                    mtgp32_kernel_params_t* k,
-                                                    int                     n,
-                                                    unsigned long long      seed)
+inline hiprandStatus_t hiprandMakeMTGP32KernelState(hiprandStateMtgp32_t* s,
+                                                    mtgp32_params_fast_t  params[],
+                                                    mtgp32_kernel_params_t* /*k*/,
+                                                    int                n,
+                                                    unsigned long long seed)
 {
     return to_hiprand_status(rocrand_make_state_mtgp32(s, params, n, seed));
 }

--- a/library/src/fortran/CMakeLists.txt
+++ b/library/src/fortran/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Fortran Wrapper
-
+message(WARNING "hipRAND's Fortran API is deprecated. hipfort should be used instead.")
 if (BUILD_WITH_LIB STREQUAL "CUDA")
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_nvcc_m.f90"

--- a/library/src/fortran/README.md
+++ b/library/src/fortran/README.md
@@ -1,0 +1,71 @@
+# Fortran API reference
+
+This library provides a pure Fortran interface for the hipRAND API.
+
+This interface is intended to target only Host API functions, and provides a mapping to some of
+the C Host API functions in hipRAND. For documentation of these functions, please
+refer to the C Host API functions documentation.
+
+## Deprecation notice
+
+This library is currently deprecated in favor of [hipfort](https://github/ROCm/hipfort).
+
+## Build and install
+
+The Fortran interface is installed as part of the hipRAND package. Simply add the build
+option `-DBUILD_FORTRAN_WRAPPER=ON` when configuring the project, as below:
+
+```shell
+cmake -DBUILD_FORTRAN_WRAPPER=ON ...
+```
+
+## Running unit tests
+
+After having configured the project with testing enabled (with option `-DBUILD_TEST=ON`), follow the steps below
+to build and run the unit tests.
+
+1. Go to hipRAND build directory
+```shell
+cd /path/to/hipRAND/build
+```
+
+2. Build unit tests for Fortran interface
+```shell
+cmake --build . --target test_hiprand_fortran_wrapper
+```
+
+3. Run unit tests
+```shell
+./test/test_hiprand_fortran_wrapper
+```
+
+## Usage
+
+Below is an example of writing a simple Fortran program that generates a set of uniform values.
+
+```fortran
+integer(kind =8) :: gen
+real, target, dimension(128) :: h_x
+type(c_ptr) :: d_x
+integer(c_int) :: status
+integer(c_size_t), parameter :: output_size = 128
+status = hipMalloc(d_x, output_size * sizeof(h_x(1)))
+status = hiprandCreateGenerator(gen, HIPRAND_RNG_PSEUDO_DEFAULT)
+status = hiprandGenerateUniform(gen, d_x, output_size)
+status = hipMemcpy(c_loc(h_x), d_x, output_size * sizeof(h_x(1)), hipMemcpyDeviceToHost)
+status = hipFree(d_x)
+status = hiprandDestroyGenerator(gen)
+```
+
+And when compiling the source code with a Fortran compiler, the following should be linked[^1]:
+
+```shell
+# Compile on an NVCC platform (link CUDA libraries: cuda, cudart).
+gfortran <input-file>.f90 hip_m.f90 hiprand_m.f90 -lhiprand_fortran -lhiprand -lcuda -lcudart
+
+# Compile on an AMD platform (link HIP library: ${HIP_ROOT_DIR}/lib).
+# Note: ${HIP_ROOT_DIR} points to the directory where HIP was installed.
+gfortran <input-file>.f90 hip_m.f90 hiprand_m.f90 -lhiprand_fortran -lhiprand -L${HIP_ROOT_DIR}/lib
+```
+
+[^1]: `gfortran` is used in this example, however other Fortran compilers should work.

--- a/library/src/fortran/hiprand_m.f90
+++ b/library/src/fortran/hiprand_m.f90
@@ -1,4 +1,4 @@
-!! Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+!! Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 !!
 !! Permission is hereby granted, free of charge, to any person obtaining a copy
 !! of this software and associated documentation files (the "Software"), to deal
@@ -18,6 +18,7 @@
 !! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 !! THE SOFTWARE.
 
+! hipRAND Fortran API is deprecated. hipfort should be used instead.
 module hiprand_m
     use hipfor
 

--- a/test/test_hiprand_kernel.cpp
+++ b/test/test_hiprand_kernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,691 +28,29 @@
 
 #include <hip/hip_runtime.h>
 #include <hiprand/hiprand.h>
-
-// hiprand_kernel.h also defines 'QUALIFIERS', we want to override this.
-#define QUALIFIERS __forceinline__ __host__ __device__
 #include <hiprand/hiprand_kernel.h>
+#include <hiprand/hiprand_mtgp32_host.h>
+
+#if defined(__HIP_PLATFORM_AMD__)
+    #include <rocrand/rocrand_mtgp32_11213.h>
+#else // for HIP NVCC platfrom
+    #include <curand_mtgp32dc_p_11213.h>
+#endif // __HIP_PLATFORM_AMD__
 
 #include "test_common.hpp"
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_init_kernel(GeneratorState * states,
-                         const size_t states_size,
-                         unsigned long long seed,
-                         unsigned long long offset)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int subsequence = state_id;
-    if(state_id < states_size)
-    {
-        GeneratorState state;
-        hiprand_init(seed, subsequence, offset, &state);
-        states[state_id] = state;
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_skip_kernel(GeneratorState * states,
-                         const size_t states_size,
-                         unsigned long long seed,
-                         unsigned long long offset)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int subsequence = state_id;
-    if(state_id < states_size)
-    {
-        GeneratorState state;
-        hiprand_init(seed, 0, offset, &state);
-        skipahead(1ULL, &state);
-        skipahead_sequence(subsequence, &state);
-        states[state_id] = state;
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_kernel(unsigned int * output, const size_t size)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
-
-    GeneratorState state;
-    const unsigned int subsequence = state_id;
-    hiprand_init(12345, subsequence, 0, &state);
-
-    unsigned int index = state_id;
-    const size_t r = size%hipBlockDim_x;
-    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
-    while(index < size_rounded_up)
-    {
-        auto value = hiprand(&state);
-        if(index < size)
-            output[index] = value;
-        index += global_size;
-    }
-}
-
-template<class T, class StateType>
-__forceinline__ __device__ auto hiprand_auto(StateType* state) ->
-    typename std::enable_if<std::is_same<T, unsigned int>::value, unsigned int>::type
-{
-    return hiprand(state);
-}
-
-template<class T, class StateType>
-__forceinline__ __device__ auto hiprand_auto(StateType* state) ->
-    typename std::enable_if<std::is_same<T, unsigned long long>::value, unsigned long long>::type
-{
-    return hiprand_long_long(state);
-}
-
-// Utility type to easily convert from
-//   unsigned int       => hiprandDirectionVectors32_t (aka. unsigned int[32])
-//   unsigned long long => hiprandDirectionVectors64_t (aka. unsigned long long[64])
-template<typename T>
-using DirectionVectors_t = T[sizeof(T) * 8];
-
-template<class GeneratorState, class IntType>
-__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_sobol_kernel(
-    IntType* output, DirectionVectors_t<IntType>* vectors, const size_t items_per_dimension)
-{
-    const unsigned int state_id  = blockIdx.x * blockDim.x + threadIdx.x;
-    const unsigned int dimension = blockIdx.y;
-
-    const unsigned int threads_per_dim = gridDim.x * blockDim.x;
-    const unsigned int items_per_thread
-        = (items_per_dimension + threads_per_dim - 1) / threads_per_dim;
-
-    const unsigned int block_offset  = state_id * items_per_thread;
-    const unsigned int global_offset = dimension * items_per_dimension;
-
-    GeneratorState state;
-    hiprand_init(vectors[0], state_id, &state);
-
-    for(unsigned int i = 0; block_offset + i < items_per_dimension; i++)
-    {
-        output[global_offset + block_offset + i] = hiprand_auto<IntType>(&state);
-    }
-}
-
-template<class GeneratorState, class IntType>
-__global__
-    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_scrambled_sobol_kernel(
-        IntType*                     output,
-        DirectionVectors_t<IntType>* vectors,
-        IntType*                     constants,
-        const size_t                 items_per_dimension)
-{
-    const unsigned int state_id  = blockIdx.x * blockDim.x + threadIdx.x;
-    const unsigned int dimension = blockIdx.y;
-
-    const unsigned int threads_per_dim = gridDim.x * blockDim.x;
-    const unsigned int items_per_thread
-        = (items_per_dimension + threads_per_dim - 1) / threads_per_dim;
-
-    const unsigned int block_offset  = state_id * items_per_thread;
-    const unsigned int global_offset = dimension * items_per_dimension;
-    GeneratorState     state;
-    hiprand_init(vectors[0], constants[dimension], block_offset, &state);
-
-    for(unsigned int i = 0; block_offset + i < items_per_dimension; i++)
-    {
-        output[global_offset + block_offset + i] = hiprand_auto<IntType>(&state);
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_uniform_kernel(float * output, const size_t size)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
-
-    GeneratorState state;
-    const unsigned int subsequence = state_id;
-    hiprand_init(12345, subsequence, 0, &state);
-
-    unsigned int index = state_id;
-    const size_t r = size%hipBlockDim_x;
-    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
-    while(index < size_rounded_up)
-    {
-        auto value = hiprand_uniform(&state);
-        if(index < size)
-            output[index] = value;
-        index += global_size;
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_normal_kernel(float * output, const size_t size)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
-
-    GeneratorState state;
-    const unsigned int subsequence = state_id;
-    hiprand_init(12345, subsequence, 0, &state);
-
-    unsigned int index = state_id;
-    const size_t r = size%hipBlockDim_x;
-    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
-    while(index < size_rounded_up)
-    {
-        float value;
-        if(hipBlockIdx_x % 2 == 0)
-            value = hiprand_normal2(&state).x;
-        else
-            value = hiprand_normal(&state);
-
-        if(index < size)
-            output[index] = value;
-        index += global_size;
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_log_normal_kernel(float * output, const size_t size)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
-
-    GeneratorState state;
-    const unsigned int subsequence = state_id;
-    hiprand_init(12345, subsequence, 0, &state);
-
-    unsigned int index = state_id;
-    const size_t r = size%hipBlockDim_x;
-    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
-    while(index < size_rounded_up)
-    {
-        float value;
-        if(hipBlockIdx_x % 2 == 0)
-            value = hiprand_log_normal2(&state, 1.6f, 0.25f).x;
-        else
-            value = hiprand_log_normal(&state, 1.6f, 0.25f);
-
-        if(index < size)
-            output[index] = value;
-        index += global_size;
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_poisson_kernel(unsigned int * output, const size_t size, double lambda)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
-
-    GeneratorState state;
-    const unsigned int subsequence = state_id;
-    hiprand_init(12345, subsequence, 0, &state);
-
-    unsigned int index = state_id;
-    const size_t r = size%hipBlockDim_x;
-    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
-    while(index < size_rounded_up)
-    {
-        auto value = hiprand_poisson(&state, lambda);
-        if(index < size)
-            output[index] = value;
-        index += global_size;
-    }
-}
-
-template <class GeneratorState>
-__global__
-__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
-void hiprand_discrete_kernel(unsigned int * output, const size_t size, hiprandDiscreteDistribution_t discrete_distribution)
-{
-    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
-
-    GeneratorState state;
-    const unsigned int subsequence = state_id;
-    hiprand_init(12345, subsequence, 0, &state);
-
-    unsigned int index = state_id;
-    const size_t r = size%hipBlockDim_x;
-    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
-    while(index < size_rounded_up)
-    {
-        auto value = hiprand_discrete(&state, discrete_distribution);
-        if(index < size)
-            output[index] = value;
-        index += global_size;
-    }
-}
-
-template<class T>
-void hiprand_kernel_h_hiprand_init_test()
-{
-    typedef T state_type;
-
-    unsigned long long seed = 0xdeadbeefbeefdeadULL;
-    unsigned long long offset = 4;
-
-    const size_t states_size = 256;
-    state_type * states;
-    HIP_CHECK(hipMallocHelper((void **)&states, states_size * sizeof(state_type)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_init_kernel),
-        dim3(4), dim3(64), 0, 0,
-        states, states_size,
-        seed, offset
-    );
-    HIP_CHECK(hipGetLastError());
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(states));
-}
-
-TEST(hiprand_kernel_h_philox4x32_10, hiprand_init)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-    hiprand_kernel_h_hiprand_init_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_mrg32k3a, hiprand_init)
-{
-    typedef hiprandStateMRG32k3a_t state_type;
-    hiprand_kernel_h_hiprand_init_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_xorwow, hiprand_init)
-{
-    typedef hiprandStateXORWOW_t state_type;
-    hiprand_kernel_h_hiprand_init_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_default, hiprand_init)
-{
-    typedef hiprandState_t state_type;
-    hiprand_kernel_h_hiprand_init_test<state_type>();
-}
-
-#ifdef __HIP_PLATFORM_NVIDIA__
-TEST(hiprand_kernel_h_philox4x32_10, hiprand_init_nvcc)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-
-    unsigned long long seed = 0xdeadbeefbeefdeadULL;
-    unsigned long long offset = 4 * ((UINT_MAX * 17ULL) + 17);
-
-    const size_t states_size = 256;
-    state_type * states;
-    HIP_CHECK(hipMallocHelper((void **)&states, states_size * sizeof(state_type)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_init_kernel),
-        dim3(4), dim3(64), 0, 0,
-        states, states_size,
-        seed, offset
-    );
-    HIP_CHECK(hipGetLastError());
-
-    std::vector<state_type> states_host(states_size);
-    HIP_CHECK(
-        hipMemcpy(
-            states_host.data(), states,
-            states_size * sizeof(state_type),
-            hipMemcpyDeviceToHost
-        )
-    );
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(states));
-
-    unsigned int subsequence = 0;
-    for(auto& s : states_host)
-    {
-        EXPECT_EQ(s.key.x, 0xbeefdeadU);
-        EXPECT_EQ(s.key.y, 0xdeadbeefU);
-
-        EXPECT_EQ(s.ctr.x, 0U);
-        EXPECT_EQ(s.ctr.y, 17U);
-        EXPECT_EQ(s.ctr.z, subsequence);
-        EXPECT_EQ(s.ctr.w, 0U);
-
-        EXPECT_TRUE(
-            s.output.x != 0U
-            || s.output.y != 0U
-            || s.output.z != 0U
-            || s.output.w
-        );
-
-        EXPECT_EQ(s.STATE, 0U);
-
-        subsequence++;
-    }
-}
-
-TEST(hiprand_kernel_h_philox4x32_10, hiprand_skip_nvcc)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-
-    unsigned long long seed = 0xdeadbeefbeefdeadULL;
-    unsigned long long offset = 4 * ((UINT_MAX * 17ULL) + 17);
-
-    const size_t states_size = 256;
-    state_type * states;
-    HIP_CHECK(hipMallocHelper((void **)&states, states_size * sizeof(state_type)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_skip_kernel),
-        dim3(4), dim3(64), 0, 0,
-        states, states_size,
-        seed, offset
-    );
-    HIP_CHECK(hipGetLastError());
-
-    std::vector<state_type> states_host(states_size);
-    HIP_CHECK(
-        hipMemcpy(
-            states_host.data(), states,
-            states_size * sizeof(state_type),
-            hipMemcpyDeviceToHost
-        )
-    );
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(states));
-
-    unsigned int subsequence = 0;
-    for(auto& s : states_host)
-    {
-        EXPECT_EQ(s.ctr.x, 0U);
-        EXPECT_EQ(s.ctr.y, 17U);
-        EXPECT_EQ(s.ctr.z, subsequence);
-        EXPECT_EQ(s.ctr.w, 0U);
-        EXPECT_EQ(s.STATE, 1U);
-        subsequence++;
-    }
-}
-#endif
-
-template<class T>
-void hiprand_kernel_h_hiprand_test()
-{
-    typedef T state_type;
-
-    const size_t output_size = 8192;
-    unsigned int * output;
-    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(unsigned int)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_kernel<state_type>),
-        dim3(4), dim3(64), 0, 0,
-        output, output_size
-    );
-    HIP_CHECK(hipGetLastError());
-
-    std::vector<unsigned int> output_host(output_size);
-    HIP_CHECK(
-        hipMemcpy(
-            output_host.data(), output,
-            output_size * sizeof(unsigned int),
-            hipMemcpyDeviceToHost
-        )
-    );
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(output));
-
-    double mean = 0;
-    for(auto v : output_host)
-    {
-        mean += static_cast<double>(v) / UINT_MAX;
-    }
-    mean = mean / output_size;
-    EXPECT_NEAR(mean, 0.5, 0.1);
-}
-
-TEST(hiprand_kernel_h_philox4x32_10, hiprand)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-    hiprand_kernel_h_hiprand_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_mrg32k3a, hiprand)
-{
-    typedef hiprandStateMRG32k3a_t state_type;
-    hiprand_kernel_h_hiprand_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_xorwow, hiprand)
-{
-    typedef hiprandStateXORWOW_t state_type;
-    hiprand_kernel_h_hiprand_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_default, hiprand)
-{
-    typedef hiprandState_t state_type;
-    hiprand_kernel_h_hiprand_test<state_type>();
-}
-
-template<class T>
-void hiprand_kernel_h_hiprand_uniform_test()
-{
-    typedef T state_type;
-
-    const size_t output_size = 8192;
-    float * output;
-    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(float)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_uniform_kernel<state_type>),
-        dim3(4), dim3(64), 0, 0,
-        output, output_size
-    );
-    HIP_CHECK(hipGetLastError());
-
-    std::vector<float> output_host(output_size);
-    HIP_CHECK(
-        hipMemcpy(
-            output_host.data(), output,
-            output_size * sizeof(float),
-            hipMemcpyDeviceToHost
-        )
-    );
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(output));
-
-    double mean = 0;
-    for(auto v : output_host)
-    {
-        mean += static_cast<double>(v);
-    }
-    mean = mean / output_size;
-    EXPECT_NEAR(mean, 0.5, 0.1);
-}
-
-TEST(hiprand_kernel_h_philox4x32_10, hiprand_uniform)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-    hiprand_kernel_h_hiprand_uniform_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_mrg32k3a, hiprand_uniform)
-{
-    typedef hiprandStateMRG32k3a_t state_type;
-    hiprand_kernel_h_hiprand_uniform_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_xorwow, hiprand_uniform)
-{
-    typedef hiprandStateXORWOW_t state_type;
-    hiprand_kernel_h_hiprand_uniform_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_default, hiprand_uniform)
-{
-    typedef hiprandState_t state_type;
-    hiprand_kernel_h_hiprand_uniform_test<state_type>();
-}
-
-template<class T>
-void hiprand_kernel_h_hiprand_normal_test()
-{
-    typedef T state_type;
-
-    const size_t output_size = 8192;
-    float * output;
-    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(float)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_normal_kernel<state_type>),
-        dim3(4), dim3(64), 0, 0,
-        output, output_size
-    );
-    HIP_CHECK(hipGetLastError());
-
-    std::vector<float> output_host(output_size);
-    HIP_CHECK(
-        hipMemcpy(
-            output_host.data(), output,
-            output_size * sizeof(float),
-            hipMemcpyDeviceToHost
-        )
-    );
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(output));
-
-    double mean = 0;
-    for(auto v : output_host)
-    {
-        mean += static_cast<double>(v);
-    }
-    mean = mean / output_size;
-    EXPECT_NEAR(mean, 0.0, 0.2);
-
-    double stddev = 0;
-    for(auto v : output_host)
-    {
-        stddev += std::pow(static_cast<double>(v) - mean, 2);
-    }
-    stddev = stddev / output_size;
-    EXPECT_NEAR(stddev, 1.0, 0.2);
-}
-
-TEST(hiprand_kernel_h_philox4x32_10, hiprand_normal)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-    hiprand_kernel_h_hiprand_normal_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_mrg32k3a, hiprand_normal)
-{
-    typedef hiprandStateMRG32k3a_t state_type;
-    hiprand_kernel_h_hiprand_normal_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_xorwow, hiprand_normal)
-{
-    typedef hiprandStateXORWOW_t state_type;
-    hiprand_kernel_h_hiprand_normal_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_default, hiprand_normal)
-{
-    typedef hiprandState_t state_type;
-    hiprand_kernel_h_hiprand_normal_test<state_type>();
-}
-
-template<class T>
-void hiprand_kernel_h_hiprand_log_normal_test()
-{
-    typedef T state_type;
-
-    const size_t output_size = 8192;
-    float * output;
-    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(float)));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_log_normal_kernel<state_type>),
-        dim3(4), dim3(64), 0, 0,
-        output, output_size
-    );
-    HIP_CHECK(hipGetLastError());
-
-    std::vector<float> output_host(output_size);
-    HIP_CHECK(
-        hipMemcpy(
-            output_host.data(), output,
-            output_size * sizeof(float),
-            hipMemcpyDeviceToHost
-        )
-    );
-    HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(hipFree(output));
-
-    double mean = 0;
-    for(auto v : output_host)
-    {
-        mean += static_cast<double>(v);
-    }
-    mean = mean / output_size;
-
-    double stddev = 0;
-    for(auto v : output_host)
-    {
-        stddev += std::pow(v - mean, 2);
-    }
-    stddev = std::sqrt(stddev / output_size);
-
-    double logmean = std::log(mean * mean / std::sqrt(stddev + mean * mean));
-    double logstd = std::sqrt(std::log(1.0f + stddev/(mean * mean)));
-
-    EXPECT_NEAR(1.6, logmean, 1.6 * 0.2);
-    EXPECT_NEAR(0.25, logstd, 0.25 * 0.2);
-}
-
-TEST(hiprand_kernel_h_philox4x32_10, hiprand_log_normal)
-{
-    typedef hiprandStatePhilox4_32_10_t state_type;
-    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_mrg32k3a, hiprand_log_normal)
-{
-    typedef hiprandStateMRG32k3a_t state_type;
-    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_xorwow, hiprand_log_normal)
-{
-    typedef hiprandStateXORWOW_t state_type;
-    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
-}
-
-TEST(hiprand_kernel_h_default, hiprand_log_normal)
-{
-    typedef hiprandState_t state_type;
-    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
-}
 
 template<class T>
 struct is_sobol_scrambled
     : std::integral_constant<bool,
                              std::is_same<T, hiprandStateScrambledSobol32>::value
                                  || std::is_same<T, hiprandStateScrambledSobol64>::value>
+{};
+
+template<class T>
+struct is_sobol_32
+    : std::integral_constant<bool,
+                             std::is_same<T, hiprandStateSobol32>::value
+                                 || std::is_same<T, hiprandStateScrambledSobol32>::value>
 {};
 
 template<class S>
@@ -723,6 +61,12 @@ hiprandStatus_t get_sobol_directions(hiprandDirectionVectors32_t** vector)
                              : HIPRAND_DIRECTION_VECTORS_32_JOEKUO6;
     return hiprandGetDirectionVectors32(vector, set);
 }
+
+// Utility type to easily convert from
+//   unsigned int       => hiprandDirectionVectors32_t (aka. unsigned int[32])
+//   unsigned long long => hiprandDirectionVectors64_t (aka. unsigned long long[64])
+template<typename T>
+using DirectionVectors_t = T[sizeof(T) * 8];
 
 template<class S>
 hiprandStatus_t get_sobol_directions(hiprandDirectionVectors64_t** vector)
@@ -778,6 +122,1496 @@ void load_scrambled_sobol_constants_and_vectors_to_gpu(const unsigned int      d
         hipMemcpy(*scramble_constants, h_constants, sizeof(T) * dimensions, hipMemcpyHostToDevice));
 }
 
+template <class GeneratorState>
+__global__
+__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
+void hiprand_init_kernel(GeneratorState * states,
+                         const size_t states_size,
+                         unsigned long long seed,
+                         unsigned long long offset)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int subsequence = state_id;
+    if(state_id < states_size)
+    {
+        GeneratorState state;
+        hiprand_init(seed, subsequence, offset, &state);
+        states[state_id] = state;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_init_sobol_kernel(
+    GeneratorState*    states,
+    const size_t       states_size,
+    unsigned long long offset,
+    direction_vectors* dir_vecs)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    if(state_id < states_size)
+    {
+        GeneratorState state;
+        hiprand_init(*dir_vecs, offset, &state);
+        states[state_id] = state;
+    }
+}
+
+template <class GeneratorState>
+__global__
+__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
+void hiprand_skip_kernel(GeneratorState * states,
+                         const size_t states_size,
+                         unsigned long long seed,
+                         unsigned long long offset)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int subsequence = state_id;
+    if(state_id < states_size)
+    {
+        GeneratorState state;
+        hiprand_init(seed, 0, offset, &state);
+        skipahead(1ULL, &state);
+        skipahead_sequence(subsequence, &state);
+        states[state_id] = state;
+    }
+}
+
+template <class GeneratorState>
+__global__
+__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
+void hiprand_kernel(unsigned int * output, const size_t size)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    const unsigned int subsequence = state_id;
+    hiprand_init(12345, subsequence, 0, &state);
+
+    unsigned int index = state_id;
+    const size_t r = size%hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand(&state);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors, typename T>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_sobol_kernel(
+    T* output, const size_t size, direction_vectors* dir_vecs)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    hiprand_init(*dir_vecs, state_id, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = sizeof(T) == 4 ? hiprand(&state) : hiprand_long_long(&state);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_mtgp_kernel(
+    GeneratorState* states, unsigned int* output, const size_t size)
+{
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    __shared__ GeneratorState state;
+    if(threadIdx.x == 0)
+    {
+        state = states[blockIdx.x];
+    }
+    __syncthreads();
+
+    unsigned int index           = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand(&state);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class T, class StateType>
+__forceinline__ __device__ auto hiprand_auto(StateType* state) ->
+    typename std::enable_if<std::is_same<T, unsigned int>::value, unsigned int>::type
+{
+    return hiprand(state);
+}
+
+template<class T, class StateType>
+__forceinline__ __device__ auto hiprand_auto(StateType* state) ->
+    typename std::enable_if<std::is_same<T, unsigned long long>::value, unsigned long long>::type
+{
+    return hiprand_long_long(state);
+}
+
+template<class GeneratorState, class IntType>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_sobol_kernel(
+    IntType* output, DirectionVectors_t<IntType>* vectors, const size_t items_per_dimension)
+{
+    const unsigned int state_id  = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int dimension = blockIdx.y;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    const unsigned int threads_per_dim = gridDim.x * blockDim.x;
+    const unsigned int items_per_thread
+        = (items_per_dimension + threads_per_dim - 1) / threads_per_dim;
+
+    const unsigned int block_offset  = state_id * items_per_thread;
+    const unsigned int global_offset = dimension * items_per_dimension;
+
+    GeneratorState state;
+    hiprand_init(vectors[dimension], block_offset, &state);
+
+    for(unsigned int i = 0; block_offset + i < items_per_dimension; i++)
+    {
+        output[global_offset + block_offset + i] = hiprand_auto<IntType>(&state);
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState, class IntType>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_scrambled_sobol_kernel(
+        IntType*                     output,
+        DirectionVectors_t<IntType>* vectors,
+        IntType*                     constants,
+        const size_t                 items_per_dimension)
+{
+    const unsigned int state_id  = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int dimension = blockIdx.y;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    const unsigned int threads_per_dim = gridDim.x * blockDim.x;
+    const unsigned int items_per_thread
+        = (items_per_dimension + threads_per_dim - 1) / threads_per_dim;
+
+    const unsigned int block_offset  = state_id * items_per_thread;
+    const unsigned int global_offset = dimension * items_per_dimension;
+    GeneratorState     state;
+    hiprand_init(vectors[dimension], constants[dimension], block_offset, &state);
+
+    for(unsigned int i = 0; block_offset + i < items_per_dimension; i++)
+    {
+        output[global_offset + block_offset + i] = hiprand_auto<IntType>(&state);
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template <class GeneratorState>
+__global__
+__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
+void hiprand_uniform_kernel(float * output, const size_t size)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    const unsigned int subsequence = state_id;
+    hiprand_init(12345, subsequence, 0, &state);
+
+    unsigned int index = state_id;
+    const size_t r = size%hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_uniform(&state);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_uniform_sobol_kernel(
+        float* output, const size_t size, direction_vectors* dir_vecs)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    hiprand_init(*dir_vecs, state_id, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_uniform(&state);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_uniform_mtgp_kernel(
+    GeneratorState* states, float* output, const size_t size)
+{
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    __shared__ GeneratorState state;
+    if(threadIdx.x == 0)
+    {
+        state = states[blockIdx.x];
+    }
+    __syncthreads();
+
+    unsigned int index           = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_uniform(&state);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template <class GeneratorState>
+__global__
+__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
+void hiprand_normal_kernel(float * output, const size_t size)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    const unsigned int subsequence = state_id;
+    hiprand_init(12345, subsequence, 0, &state);
+
+    unsigned int index = state_id;
+    const size_t r = size%hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        float value;
+        if(hipBlockIdx_x % 2 == 0)
+            value = hiprand_normal2(&state).x;
+        else
+            value = hiprand_normal(&state);
+
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_normal_sobol_kernel(
+    float* output, const size_t size, direction_vectors* dir_vecs)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    hiprand_init(*dir_vecs, state_id, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        float value = hiprand_normal(&state);
+
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_normal_mtgp_kernel(
+    GeneratorState* states, float* output, const size_t size)
+{
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    __shared__ GeneratorState state;
+    if(threadIdx.x == 0)
+    {
+        state = states[blockIdx.x];
+    }
+    __syncthreads();
+
+    unsigned int index           = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        float value = hiprand_normal(&state);
+
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template <class GeneratorState>
+__global__
+__launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU)
+void hiprand_log_normal_kernel(float * output, const size_t size)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    const unsigned int subsequence = state_id;
+    hiprand_init(12345, subsequence, 0, &state);
+
+    unsigned int index = state_id;
+    const size_t r = size%hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        float value;
+        if(hipBlockIdx_x % 2 == 0)
+            value = hiprand_log_normal2(&state, 1.6f, 0.25f).x;
+        else
+            value = hiprand_log_normal(&state, 1.6f, 0.25f);
+
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_log_normal_sobol_kernel(
+        float* output, const size_t size, direction_vectors* dir_vecs)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    hiprand_init(*dir_vecs, state_id, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        float value = hiprand_log_normal(&state, 1.6f, 0.25f);
+
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_log_normal_mtgp_kernel(
+        GeneratorState* states, float* output, const size_t size)
+{
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    __shared__ GeneratorState state;
+    if(threadIdx.x == 0)
+    {
+        state = states[blockIdx.x];
+    }
+    __syncthreads();
+
+    unsigned int index           = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        float value = hiprand_log_normal(&state, 1.6f, 0.25f);
+
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_poisson_kernel(
+    unsigned int* output, const size_t size, double lambda)
+{
+    const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    const unsigned int subsequence = state_id;
+    hiprand_init(12345, subsequence, 0, &state);
+
+    unsigned int index = state_id;
+    const size_t r = size%hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_poisson(&state, lambda);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_poisson_sobol_kernel(
+        unsigned int* output, const size_t size, double lambda, direction_vectors* dir_vecs)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    hiprand_init(*dir_vecs, state_id, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_poisson(&state, lambda);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_poisson_mtgp_kernel(
+    GeneratorState* states, unsigned int* output, const size_t size, double lambda)
+{
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    __shared__ GeneratorState state;
+    if(threadIdx.x == 0)
+    {
+        state = states[blockIdx.x];
+    }
+    __syncthreads();
+
+    unsigned int index           = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_poisson(&state, lambda);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState>
+__global__ __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_discrete_kernel(
+    unsigned int* output, const size_t size, hiprandDiscreteDistribution_t discrete_distribution)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState     state;
+    const unsigned int subsequence = state_id;
+    hiprand_init(12345, subsequence, 0, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_discrete(&state, discrete_distribution);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class GeneratorState, typename direction_vectors>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_discrete_sobol_kernel(
+        unsigned int*                 output,
+        const size_t                  size,
+        hiprandDiscreteDistribution_t discrete_distribution,
+        direction_vectors*            dir_vecs)
+{
+    const unsigned int state_id    = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    GeneratorState state;
+    hiprand_init(*dir_vecs, state_id, &state);
+
+    unsigned int index           = state_id;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_discrete(&state, discrete_distribution);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+        skipahead(global_size - 1, &state);
+    }
+}
+
+template<class GeneratorState>
+__global__
+    __launch_bounds__(64, HIPRAND_DEFAULT_MIN_WARPS_PER_EU) void hiprand_discrete_mtgp_kernel(
+        GeneratorState*               states,
+        unsigned int*                 output,
+        const size_t                  size,
+        hiprandDiscreteDistribution_t discrete_distribution)
+{
+    const unsigned int global_size = hipGridDim_x * hipBlockDim_x;
+
+    __shared__ GeneratorState state;
+    if(threadIdx.x == 0)
+    {
+        state = states[blockIdx.x];
+    }
+    __syncthreads();
+
+    unsigned int index           = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const size_t r               = size % hipBlockDim_x;
+    const size_t size_rounded_up = r == 0 ? size : size + (hipBlockDim_x - r);
+    while(index < size_rounded_up)
+    {
+        auto value = hiprand_discrete(&state, discrete_distribution);
+        if(index < size)
+            output[index] = value;
+        index += global_size;
+    }
+}
+
+template<class T>
+void hiprand_kernel_h_hiprand_init_test()
+{
+    typedef T state_type;
+
+    unsigned long long seed   = 0xdeadbeefbeefdeadULL;
+    unsigned long long offset = 4;
+
+    const size_t states_size = 256;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_init_kernel<<<dim3(4), dim3(64), 0, 0>>>(states, states_size, seed, offset);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(states));
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_sobol_init_test()
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    unsigned long long offset = 4;
+
+    const size_t states_size = 256;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_init_sobol_kernel<<<dim3(4), dim3(64), 0, 0>>>(states, states_size, offset, d_vector);
+
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(states));
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_mtgp_init_test()
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    HIP_CHECK(hipFree(states));
+}
+
+TEST(hiprand_kernel_h_philox4x32_10, hiprand_init)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+    hiprand_kernel_h_hiprand_init_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mrg32k3a, hiprand_init)
+{
+    typedef hiprandStateMRG32k3a_t state_type;
+    hiprand_kernel_h_hiprand_init_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_xorwow, hiprand_init)
+{
+    typedef hiprandStateXORWOW_t state_type;
+    hiprand_kernel_h_hiprand_init_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_default, hiprand_init)
+{
+    typedef hiprandState_t state_type;
+    hiprand_kernel_h_hiprand_init_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_32, hiprand_init)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_sobol_init_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_64, hiprand_init)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_sobol_init_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mtgp_32, hiprand_init)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_mtgp_init_test<state_type>();
+}
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+TEST(hiprand_kernel_h_philox4x32_10, hiprand_init_nvcc)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+
+    unsigned long long seed = 0xdeadbeefbeefdeadULL;
+    unsigned long long offset = 4 * ((UINT_MAX * 17ULL) + 17);
+
+    const size_t states_size = 256;
+    state_type * states;
+    HIP_CHECK(hipMallocHelper((void **)&states, states_size * sizeof(state_type)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_init_kernel<<<dim3(4), dim3(64), 0, 0>>>(states, states_size, seed, offset);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<state_type> states_host(states_size);
+    HIP_CHECK(
+        hipMemcpy(
+            states_host.data(), states,
+            states_size * sizeof(state_type),
+            hipMemcpyDeviceToHost
+        )
+    );
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(states));
+
+    unsigned int subsequence = 0;
+    for(auto& s : states_host)
+    {
+        EXPECT_EQ(s.key.x, 0xbeefdeadU);
+        EXPECT_EQ(s.key.y, 0xdeadbeefU);
+
+        EXPECT_EQ(s.ctr.x, 0U);
+        EXPECT_EQ(s.ctr.y, 17U);
+        EXPECT_EQ(s.ctr.z, subsequence);
+        EXPECT_EQ(s.ctr.w, 0U);
+
+        EXPECT_TRUE(
+            s.output.x != 0U
+            || s.output.y != 0U
+            || s.output.z != 0U
+            || s.output.w
+        );
+
+        EXPECT_EQ(s.STATE, 0U);
+
+        subsequence++;
+    }
+}
+
+TEST(hiprand_kernel_h_philox4x32_10, hiprand_skip_nvcc)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+
+    unsigned long long seed = 0xdeadbeefbeefdeadULL;
+    unsigned long long offset = 4 * ((UINT_MAX * 17ULL) + 17);
+
+    const size_t states_size = 256;
+    state_type * states;
+    HIP_CHECK(hipMallocHelper((void **)&states, states_size * sizeof(state_type)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_skip_kernel<<<dim3(4), dim3(64), 0, 0>>>(states, states_size, seed, offset);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<state_type> states_host(states_size);
+    HIP_CHECK(
+        hipMemcpy(
+            states_host.data(), states,
+            states_size * sizeof(state_type),
+            hipMemcpyDeviceToHost
+        )
+    );
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(states));
+
+    unsigned int subsequence = 0;
+    for(auto& s : states_host)
+    {
+        EXPECT_EQ(s.ctr.x, 0U);
+        EXPECT_EQ(s.ctr.y, 17U);
+        EXPECT_EQ(s.ctr.z, subsequence);
+        EXPECT_EQ(s.ctr.w, 0U);
+        EXPECT_EQ(s.STATE, 1U);
+        subsequence++;
+    }
+}
+#endif
+
+template<class T>
+void hiprand_kernel_h_hiprand_test()
+{
+    typedef T state_type;
+
+    const size_t output_size = 8192;
+    unsigned int * output;
+    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(unsigned int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<unsigned int> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(
+            output_host.data(), output,
+            output_size * sizeof(unsigned int),
+            hipMemcpyDeviceToHost
+        )
+    );
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v) / UINT_MAX;
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.5, 0.1);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_sobol_test()
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    const size_t output_size = 8192;
+    int_type*    output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(int_type)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_sobol_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(output, output_size, d_vector);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<int_type> output_host(output_size);
+    HIP_CHECK(hipMemcpy(output_host.data(),
+                        output,
+                        output_size * sizeof(int_type),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v)
+                / static_cast<double>(is_sobol_32<state_type>::value ? UINT_MAX : ULONG_LONG_MAX);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.5, 0.1);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_mtgp_test()
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    const size_t  output_size = 8192;
+    unsigned int* output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(unsigned int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_mtgp_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(states, output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<unsigned int> output_host(output_size);
+    HIP_CHECK(hipMemcpy(output_host.data(),
+                        output,
+                        output_size * sizeof(unsigned int),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(states));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v) / UINT_MAX;
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.5, 0.1);
+}
+
+TEST(hiprand_kernel_h_philox4x32_10, hiprand)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+    hiprand_kernel_h_hiprand_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mrg32k3a, hiprand)
+{
+    typedef hiprandStateMRG32k3a_t state_type;
+    hiprand_kernel_h_hiprand_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_xorwow, hiprand)
+{
+    typedef hiprandStateXORWOW_t state_type;
+    hiprand_kernel_h_hiprand_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_default, hiprand)
+{
+    typedef hiprandState_t state_type;
+    hiprand_kernel_h_hiprand_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_32, hiprand)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_64, hiprand)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mtgp_32, hiprand)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_mtgp_test<state_type>();
+}
+
+template<class T>
+void hiprand_kernel_h_hiprand_uniform_test()
+{
+    typedef T state_type;
+
+    const size_t output_size = 8192;
+    float * output;
+    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_uniform_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.5, 0.1);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_uniform_sobol_test()
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_uniform_sobol_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(output, output_size, d_vector);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.5, 0.1);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_uniform_mtgp_test()
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_uniform_mtgp_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(states, output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(states));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.5, 0.1);
+}
+
+TEST(hiprand_kernel_h_philox4x32_10, hiprand_uniform)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+    hiprand_kernel_h_hiprand_uniform_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mrg32k3a, hiprand_uniform)
+{
+    typedef hiprandStateMRG32k3a_t state_type;
+    hiprand_kernel_h_hiprand_uniform_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_xorwow, hiprand_uniform)
+{
+    typedef hiprandStateXORWOW_t state_type;
+    hiprand_kernel_h_hiprand_uniform_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_default, hiprand_uniform)
+{
+    typedef hiprandState_t state_type;
+    hiprand_kernel_h_hiprand_uniform_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_32, hiprand_uniform)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_uniform_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_64, hiprand_uniform)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_uniform_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mtgp_32, hiprand_uniform)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_uniform_mtgp_test<state_type>();
+}
+
+template<class T>
+void hiprand_kernel_h_hiprand_normal_test()
+{
+    typedef T state_type;
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_normal_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.0, 0.2);
+
+    double stddev = 0;
+    for(auto v : output_host)
+    {
+        stddev += std::pow(static_cast<double>(v) - mean, 2);
+    }
+    stddev = stddev / output_size;
+    EXPECT_NEAR(stddev, 1.0, 0.2);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_normal_sobol_test()
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_normal_sobol_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(output, output_size, d_vector);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.0, 0.2);
+
+    double stddev = 0;
+    for(auto v : output_host)
+    {
+        stddev += std::pow(static_cast<double>(v) - mean, 2);
+    }
+    stddev = stddev / output_size;
+    EXPECT_NEAR(stddev, 1.0, 0.2);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_normal_mtgp_test()
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_normal_mtgp_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(states, output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(
+            output_host.data(), output,
+            output_size * sizeof(float),
+            hipMemcpyDeviceToHost
+        )
+    );
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(states));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+    EXPECT_NEAR(mean, 0.0, 0.2);
+
+    double stddev = 0;
+    for(auto v : output_host)
+    {
+        stddev += std::pow(static_cast<double>(v) - mean, 2);
+    }
+    stddev = stddev / output_size;
+    EXPECT_NEAR(stddev, 1.0, 0.2);
+}
+
+TEST(hiprand_kernel_h_philox4x32_10, hiprand_normal)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+    hiprand_kernel_h_hiprand_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mrg32k3a, hiprand_normal)
+{
+    typedef hiprandStateMRG32k3a_t state_type;
+    hiprand_kernel_h_hiprand_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_xorwow, hiprand_normal)
+{
+    typedef hiprandStateXORWOW_t state_type;
+    hiprand_kernel_h_hiprand_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_default, hiprand_normal)
+{
+    typedef hiprandState_t state_type;
+    hiprand_kernel_h_hiprand_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_32, hiprand_normal)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_normal_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_64, hiprand_normal)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_normal_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mtgp_32, hiprand_normal)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_normal_mtgp_test<state_type>();
+}
+
+template<class T>
+void hiprand_kernel_h_hiprand_log_normal_test()
+{
+    typedef T state_type;
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_log_normal_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double stddev = 0;
+    for(auto v : output_host)
+    {
+        stddev += std::pow(v - mean, 2);
+    }
+    stddev = std::sqrt(stddev / output_size);
+
+    double logmean = std::log(mean * mean / std::sqrt(stddev + mean * mean));
+    double logstd  = std::sqrt(std::log(1.0f + stddev / (mean * mean)));
+
+    EXPECT_NEAR(1.6, logmean, 1.6 * 0.2);
+    EXPECT_NEAR(0.25, logstd, 0.25 * 0.2);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_log_normal_sobol_test()
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    const size_t output_size = 8192;
+    float*       output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_log_normal_sobol_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(output, output_size, d_vector);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double stddev = 0;
+    for(auto v : output_host)
+    {
+        stddev += std::pow(v - mean, 2);
+    }
+    stddev = std::sqrt(stddev / output_size);
+
+    double logmean = std::log(mean * mean / std::sqrt(stddev + mean * mean));
+    double logstd  = std::sqrt(std::log(1.0f + stddev / (mean * mean)));
+
+    EXPECT_NEAR(1.6, logmean, 1.6 * 0.2);
+    EXPECT_NEAR(0.25, logstd, 0.25 * 0.2);
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_log_normal_mtgp_test()
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    const size_t output_size = 8192;
+    float * output;
+    HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(float)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_log_normal_mtgp_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(states, output, output_size);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<float> output_host(output_size);
+    HIP_CHECK(
+        hipMemcpy(
+            output_host.data(), output,
+            output_size * sizeof(float),
+            hipMemcpyDeviceToHost
+        )
+    );
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(states));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double stddev = 0;
+    for(auto v : output_host)
+    {
+        stddev += std::pow(v - mean, 2);
+    }
+    stddev = std::sqrt(stddev / output_size);
+
+    double logmean = std::log(mean * mean / std::sqrt(stddev + mean * mean));
+    double logstd = std::sqrt(std::log(1.0f + stddev/(mean * mean)));
+
+    EXPECT_NEAR(1.6, logmean, 1.6 * 0.2);
+    EXPECT_NEAR(0.25, logstd, 0.25 * 0.2);
+}
+
+TEST(hiprand_kernel_h_philox4x32_10, hiprand_log_normal)
+{
+    typedef hiprandStatePhilox4_32_10_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mrg32k3a, hiprand_log_normal)
+{
+    typedef hiprandStateMRG32k3a_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_xorwow, hiprand_log_normal)
+{
+    typedef hiprandStateXORWOW_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_default, hiprand_log_normal)
+{
+    typedef hiprandState_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_32, hiprand_log_normal)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_sobol_64, hiprand_log_normal)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_sobol_test<state_type>();
+}
+
+TEST(hiprand_kernel_h_mtgp_32, hiprand_log_normal)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_log_normal_mtgp_test<state_type>();
+}
+
 template<class S, class T>
 auto launch_sobol_kernel(T*                     output,
                          DirectionVectors_t<T>* d_vector,
@@ -786,15 +1620,11 @@ auto launch_sobol_kernel(T*                     output,
                          const size_t           items_per_dimension) ->
     typename std::enable_if<is_sobol_scrambled<S>::value>::type
 {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hiprand_scrambled_sobol_kernel<S, T>),
-                       dim3(8, dimensions),
-                       dim3(32),
-                       0,
-                       0,
-                       output,
-                       d_vector,
-                       d_constants,
-                       items_per_dimension);
+    hiprand_scrambled_sobol_kernel<S, T>
+        <<<dim3(8, dimensions), dim3(32), 0, 0>>>(output,
+                                                  d_vector,
+                                                  d_constants,
+                                                  items_per_dimension);
 }
 template<class S, class T>
 auto launch_sobol_kernel(T*                     output,
@@ -804,14 +1634,8 @@ auto launch_sobol_kernel(T*                     output,
                          const size_t       items_per_dimension) ->
     typename std::enable_if<!is_sobol_scrambled<S>::value>::type
 {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hiprand_sobol_kernel<S, T>),
-                       dim3(8, dimensions),
-                       dim3(32),
-                       0,
-                       0,
-                       output,
-                       d_vector,
-                       items_per_dimension);
+    hiprand_sobol_kernel<S, T>
+        <<<dim3(8, dimensions), dim3(32), 0, 0>>>(output, d_vector, items_per_dimension);
 }
 
 template<class S, class T>
@@ -906,11 +1730,7 @@ void hiprand_kernel_h_hiprand_poisson_test(double lambda)
     HIP_CHECK(hipMallocHelper((void **)&output, output_size * sizeof(unsigned int)));
     HIP_CHECK(hipDeviceSynchronize());
 
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_poisson_kernel<state_type>),
-        dim3(4), dim3(64), 0, 0,
-        output, output_size, lambda
-    );
+    hiprand_poisson_kernel<state_type><<<dim3(4), dim3(64), 0, 0>>>(output, output_size, lambda);
     HIP_CHECK(hipGetLastError());
 
     std::vector<unsigned int> output_host(output_size);
@@ -923,6 +1743,115 @@ void hiprand_kernel_h_hiprand_poisson_test(double lambda)
     );
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double variance = 0;
+    for(auto v : output_host)
+    {
+        variance += std::pow(v - mean, 2);
+    }
+    variance = variance / output_size;
+
+    EXPECT_NEAR(mean, lambda, std::max(1.0, lambda * 1e-1));
+    EXPECT_NEAR(variance, lambda, std::max(1.0, lambda * 1e-1));
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_poisson_sobol_test(double lambda)
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    const size_t  output_size = 8192;
+    unsigned int* output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(unsigned int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_poisson_sobol_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(output, output_size, lambda, d_vector);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<unsigned int> output_host(output_size);
+    HIP_CHECK(hipMemcpy(output_host.data(),
+                        output,
+                        output_size * sizeof(unsigned int),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double variance = 0;
+    for(auto v : output_host)
+    {
+        variance += std::pow(v - mean, 2);
+    }
+    variance = variance / output_size;
+
+    EXPECT_NEAR(mean, lambda, std::max(1.0, lambda * 1e-1));
+    EXPECT_NEAR(variance, lambda, std::max(1.0, lambda * 1e-1));
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_poisson_mtgp_test(double lambda)
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    const size_t  output_size = 8192;
+    unsigned int* output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(unsigned int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprand_poisson_mtgp_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(states, output, output_size, lambda);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<unsigned int> output_host(output_size);
+    HIP_CHECK(hipMemcpy(output_host.data(),
+                        output,
+                        output_size * sizeof(unsigned int),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(states));
 
     double mean = 0;
     for(auto v : output_host)
@@ -955,11 +1884,8 @@ void hiprand_kernel_h_hiprand_discrete_test(double lambda)
     hiprandDiscreteDistribution_t discrete_distribution;
     ASSERT_EQ(hiprandCreatePoissonDistribution(lambda, &discrete_distribution), HIPRAND_STATUS_SUCCESS);
 
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(hiprand_discrete_kernel<state_type>),
-        dim3(4), dim3(64), 0, 0,
-        output, output_size, discrete_distribution
-    );
+    hiprand_discrete_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(output, output_size, discrete_distribution);
     HIP_CHECK(hipGetLastError());
 
     std::vector<unsigned int> output_host(output_size);
@@ -972,6 +1898,125 @@ void hiprand_kernel_h_hiprand_discrete_test(double lambda)
     );
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
+    ASSERT_EQ(hiprandDestroyDistribution(discrete_distribution), HIPRAND_STATUS_SUCCESS);
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double variance = 0;
+    for(auto v : output_host)
+    {
+        variance += std::pow(v - mean, 2);
+    }
+    variance = variance / output_size;
+
+    EXPECT_NEAR(mean, lambda, std::max(1.0, lambda * 1e-1));
+    EXPECT_NEAR(variance, lambda, std::max(1.0, lambda * 1e-1));
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_discrete_sobol_test(double lambda)
+{
+    using int_type = typename std::
+        conditional<is_sobol_32<state_type>::value, unsigned int, unsigned long long int>::type;
+
+    const unsigned int dimensions = 8;
+
+    DirectionVectors_t<int_type>* d_vector;
+    int_type*                     d_constants;
+
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
+                                                                                &d_vector,
+                                                                                &d_constants);
+    }
+    else
+    {
+        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+        d_constants = NULL;
+    }
+
+    const size_t  output_size = 8192;
+    unsigned int* output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(unsigned int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprandDiscreteDistribution_t discrete_distribution;
+    ASSERT_EQ(hiprandCreatePoissonDistribution(lambda, &discrete_distribution),
+              HIPRAND_STATUS_SUCCESS);
+
+    hiprand_discrete_sobol_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(output, output_size, discrete_distribution, d_vector);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<unsigned int> output_host(output_size);
+    HIP_CHECK(hipMemcpy(output_host.data(),
+                        output,
+                        output_size * sizeof(unsigned int),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    ASSERT_EQ(hiprandDestroyDistribution(discrete_distribution), HIPRAND_STATUS_SUCCESS);
+
+    double mean = 0;
+    for(auto v : output_host)
+    {
+        mean += static_cast<double>(v);
+    }
+    mean = mean / output_size;
+
+    double variance = 0;
+    for(auto v : output_host)
+    {
+        variance += std::pow(v - mean, 2);
+    }
+    variance = variance / output_size;
+
+    EXPECT_NEAR(mean, lambda, std::max(1.0, lambda * 1e-1));
+    EXPECT_NEAR(variance, lambda, std::max(1.0, lambda * 1e-1));
+}
+
+template<class state_type>
+void hiprand_kernel_h_hiprand_discrete_mtgp_test(double lambda)
+{
+    const size_t states_size = 128;
+    state_type*  states;
+    HIP_CHECK(hipMallocHelper((void**)&states, states_size * sizeof(state_type)));
+    mtgp32_kernel_params_t* k;
+    HIP_CHECK(hipMallocHelper((void**)&k, states_size * sizeof(mtgp32_kernel_params_t)));
+
+    HIP_CHECK(hiprandMakeMTGP32Constants(mtgp32dc_params_fast_11213, k));
+
+    unsigned long long seed = 0;
+    HIP_CHECK(
+        hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
+
+    const size_t  output_size = 8192;
+    unsigned int* output;
+    HIP_CHECK(hipMallocHelper((void**)&output, output_size * sizeof(unsigned int)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    hiprandDiscreteDistribution_t discrete_distribution;
+    ASSERT_EQ(hiprandCreatePoissonDistribution(lambda, &discrete_distribution),
+              HIPRAND_STATUS_SUCCESS);
+
+    hiprand_discrete_mtgp_kernel<state_type>
+        <<<dim3(4), dim3(64), 0, 0>>>(states, output, output_size, discrete_distribution);
+    HIP_CHECK(hipGetLastError());
+
+    std::vector<unsigned int> output_host(output_size);
+    HIP_CHECK(hipMemcpy(output_host.data(),
+                        output,
+                        output_size * sizeof(unsigned int),
+                        hipMemcpyDeviceToHost));
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(states));
     ASSERT_EQ(hiprandDestroyDistribution(discrete_distribution), HIPRAND_STATUS_SUCCESS);
 
     double mean = 0;
@@ -1065,3 +2110,60 @@ TEST_P(hiprand_kernel_h_default_poisson, hiprand_discrete)
 INSTANTIATE_TEST_SUITE_P(hiprand_kernel_h_default_poisson,
                         hiprand_kernel_h_default_poisson,
                         ::testing::ValuesIn(lambdas));
+
+class hiprand_kernel_h_sobol_32_poisson : public ::testing::TestWithParam<double>
+{};
+
+TEST_P(hiprand_kernel_h_sobol_32_poisson, hiprand_poisson)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_poisson_sobol_test<state_type>(GetParam());
+}
+
+TEST_P(hiprand_kernel_h_sobol_32_poisson, hiprand_discrete)
+{
+    typedef hiprandStateSobol32_t state_type;
+    hiprand_kernel_h_hiprand_discrete_sobol_test<state_type>(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(hiprand_kernel_h_sobol_32_poisson,
+                         hiprand_kernel_h_sobol_32_poisson,
+                         ::testing::ValuesIn(lambdas));
+
+class hiprand_kernel_h_sobol_64_poisson : public ::testing::TestWithParam<double>
+{};
+
+TEST_P(hiprand_kernel_h_sobol_64_poisson, hiprand_poisson)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_poisson_sobol_test<state_type>(GetParam());
+}
+
+TEST_P(hiprand_kernel_h_sobol_64_poisson, hiprand_discrete)
+{
+    typedef hiprandStateSobol64_t state_type;
+    hiprand_kernel_h_hiprand_discrete_sobol_test<state_type>(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(hiprand_kernel_h_sobol_64_poisson,
+                         hiprand_kernel_h_sobol_64_poisson,
+                         ::testing::ValuesIn(lambdas));
+
+class hiprand_kernel_h_mtgp_32_poisson : public ::testing::TestWithParam<double>
+{};
+
+TEST_P(hiprand_kernel_h_mtgp_32_poisson, hiprand_poisson)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_poisson_mtgp_test<state_type>(GetParam());
+}
+
+TEST_P(hiprand_kernel_h_mtgp_32_poisson, hiprand_discrete)
+{
+    typedef hiprandStateMtgp32_t state_type;
+    hiprand_kernel_h_hiprand_discrete_mtgp_test<state_type>(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(hiprand_kernel_h_mtgp_32_poisson,
+                         hiprand_kernel_h_mtgp_32_poisson,
+                         ::testing::ValuesIn(lambdas));


### PR DESCRIPTION
Changes:
- Fix kernel tests not including MTGP and Sobol engines, d495f14a42239f04e6c7d350caa85cb5bb779cbf.
- Deprecate Fortran interfaces, 81a7fb539d5a5ebf2626862ef4e1dee17a5a1af2.
- Log more information during configure, 2e94c73593abbc50fd1490c2e7a01ee78e9f749b.
- Move Fortran API deprecation in the changelog to ROCm 7.0, a3eca62501eaf9746e311497e113636cc8b51758.