### PR TITLE
Update hipRAND package description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ endif()
 
 rocm_create_package(
         NAME ${package_name}
-        DESCRIPTION "Radeon Open Compute RAND library"
+        DESCRIPTION "A GPU-based random number generation library, written in HIP"
         MAINTAINER "hipRAND Maintainer <hiprand-maintainer@amd.com>"
         LDCONFIG
         LDCONFIG_DIR ${HIPRAND_CONFIG_DIR}


### PR DESCRIPTION
This change updates the cmake description field in CMakeLists.txt to satisfy the current static analysis check's word scan requirements.